### PR TITLE
Fix compile error when a Config has no default value for timeout

### DIFF
--- a/source/agora/config/Config.d
+++ b/source/agora/config/Config.d
@@ -718,6 +718,7 @@ private enum isOptional (alias FR) = hasUDA!(FR.Ref, Optional) ||
 
 /// Evaluates to `true` if we should recurse into the struct via `parseDefaultMapping`
 private enum mightBeOptional (alias FR) = is(FR.Type == struct) &&
+    !is(immutable(FR.Type) == immutable(core.time.Duration)) &&
     !hasConverter!(FR.Ref) && !hasFromString!(FR.Type) && !hasStringCtor!(FR.Type);
 
 /// Convenience template to check for the presence of converter(s)
@@ -1192,4 +1193,18 @@ address:
     assert(c2.address.set);
     assert(c2.address.address == "Somewhere");
     assert(c2.address.city == "Over the rainbow");
+}
+
+unittest
+{
+    static struct Config { core.time.Duration timeout; }
+    try
+    {
+        auto result = parseConfigString!Config("timeout:", "/dev/null");
+        assert(0);
+    }
+    catch (Exception exc)
+    {
+        assert(exc.message().length);
+    }
 }


### PR DESCRIPTION
Our use case always uses default value for Duration fields,
so we weren't hit by the compile-time error.
The test is currently pretty simple as colors are always output,
making tests hard to write.