### PR TITLE
Fix #2: Make colors optional

### DIFF
--- a/source/agora/config/Config.d
+++ b/source/agora/config/Config.d
@@ -1012,6 +1012,22 @@ unittest
     }
 }
 
+unittest
+{
+    static struct Config { string required; }
+    try
+        auto result = parseConfigString!Config("value: 24", "/dev/null");
+    catch (ConfigException e)
+    {
+        assert(format("%s", e) ==
+               "<unknown>(0:0): value: Key is not a valid member of this section. There are 1 valid keys: required");
+        assert(format("%S", e) ==
+               format("%s<unknown>%s(%s0%s:%s0%s): %svalue%s: Key is not a valid member of this section. " ~
+                      "There are %s1%s valid keys: %srequired%s", Yellow, Reset, Cyan, Reset, Cyan, Reset,
+                      Yellow, Reset, Yellow, Reset, Green, Reset));
+    }
+}
+
 // Test for various type errors
 unittest
 {

--- a/source/agora/config/Config.d
+++ b/source/agora/config/Config.d
@@ -391,7 +391,8 @@ private T parseMapping (T)
             dbgWrite("Found %s (%s.%s) in `fieldDefaults",
                      FR.Name.paint(Cyan), path.paint(Cyan), FName.paint(Cyan));
 
-            node.enforce(!ctx.strict || FName !in node, "'Key' field '%s' is specified twice", path.paint(Yellow));
+            if (ctx.strict && FName in node)
+                throw new ConfigExceptionImpl("'Key' field is specified twice", path, FName, node.startMark());
             return (*ptr).parseField!(FR)(path.addPath(FName), default_, ctx)
                 .dbgWriteRet("Using value '%s' from fieldDefaults for field '%s'",
                              FName.paint(Cyan));
@@ -897,17 +898,6 @@ unittest
 private string addPath (string opath, string newPart)
 {
     return opath.length ? format("%s.%s", opath, newPart) : newPart;
-}
-
-/// Helper mixin for exception types
-private mixin template ExceptionCtor ()
-{
-    public this (string msg, Mark position,
-                 string file = __FILE__, size_t line = __LINE__)
-        @safe pure nothrow @nogc
-    {
-        super(msg, position, file, line);
-    }
 }
 
 /// Basic usage tests

--- a/source/agora/config/Config.d
+++ b/source/agora/config/Config.d
@@ -433,14 +433,7 @@ private T parseMapping (T)
             return Node(aa).parseMapping!(FR.Type)(npath, FR.Default, ctx, null);
         }
         else
-        {
-            const fmt = path.length ?
-                "'%s' was not found in '%s', nor was it provided in command line arguments" :
-                // The extra `%s` is used to allow passing the same arguments to `enforce`
-                "'%s' was not found in document%s, nor was it provided in command line arguments";
-            node.enforce(false, fmt, FR.Name, path);
-            assert(0);
-        }
+            throw new MissingKeyException(path, FName, node.startMark());
     }
 
     debug (ConfigFillerDebug)
@@ -1091,5 +1084,30 @@ unittest
     catch (ConfigException exc)
     {
         assert(exc.toString() == "<unknown>(0:0): valeu: Key is not a valid member of this section. There are 1 valid keys: value");
+    }
+}
+
+// Test for required key
+unittest
+{
+    static struct Nested
+    {
+        string required;
+        string optional = "Default";
+    }
+
+    static struct Config
+    {
+        Nested inner;
+    }
+
+    try
+    {
+        auto result = parseConfigString!Config("inner:\n  optional: Not the default value", "/dev/null");
+        assert(0);
+    }
+    catch (ConfigException exc)
+    {
+        assert(exc.toString() == "<unknown>(1:2): inner.required: Required key was not found in configuration of command line arguments");
     }
 }

--- a/source/agora/config/Exceptions.d
+++ b/source/agora/config/Exceptions.d
@@ -196,3 +196,46 @@ package final class ConfigExceptionImpl : ConfigException
         sink(this.msg);
     }
 }
+
+/// Exception thrown when the type of the YAML node does not match the D type
+package final class TypeConfigException : ConfigException
+{
+    /// The actual (in the YAML document) type of the node
+    public string actual;
+
+    /// The expected (as specified in the D type) type
+    public string expected;
+
+    /// Constructor
+    public this (Node node, string expected, string path, string key = null,
+                 string file = __FILE__, size_t line = __LINE__)
+        @safe nothrow
+    {
+        this(node.nodeTypeString(), expected, path, key, node.startMark(),
+             file, line);
+    }
+
+    /// Ditto
+    public this (string actual, string expected, string path, string key,
+                 Mark position, string file = __FILE__, size_t line = __LINE__)
+        @safe pure nothrow @nogc
+    {
+        super(path, key, position, file, line);
+        this.actual = actual;
+        this.expected = expected;
+    }
+
+    /// Format the message with or without colors
+    protected override void formatMessage (
+        scope void delegate(in char[]) sink, in FormatSpec!char spec) const scope
+    {
+        const useColors = spec.spec == 'S';
+
+        const fmt = "Expected to be of type %s, but is a %s";
+
+        if (useColors)
+            formattedWrite(sink, fmt, this.expected.paint(Green), this.actual.paint(Red));
+        else
+            formattedWrite(sink, fmt, this.expected, this.actual);
+    }
+}

--- a/source/agora/config/Exceptions.d
+++ b/source/agora/config/Exceptions.d
@@ -18,6 +18,7 @@ import agora.config.Utils;
 import dyaml.exception;
 import dyaml.node;
 
+import std.algorithm : map;
 import std.format;
 
 /// A convenience wrapper around `enforce` to throw a formatted exception
@@ -237,5 +238,35 @@ package final class TypeConfigException : ConfigException
             formattedWrite(sink, fmt, this.expected.paint(Green), this.actual.paint(Red));
         else
             formattedWrite(sink, fmt, this.expected, this.actual);
+    }
+}
+
+/// Exception thrown when an unknown key is found in strict mode
+public class UnknownKeyConfigException : ConfigException
+{
+    /// The list of valid field names
+    public immutable string[] fieldNames;
+
+    /// Constructor
+    public this (string path, string key, immutable string[] fieldNames,
+                 Mark position, string file = __FILE__, size_t line = __LINE__)
+        @safe pure nothrow @nogc
+    {
+        super(path, key, position, file, line);
+        this.fieldNames = fieldNames;
+    }
+
+    /// Format the message with or without colors
+    protected override void formatMessage (
+        scope void delegate(in char[]) sink, in FormatSpec!char spec) const scope
+    {
+        const useColors = spec.spec == 'S';
+        const fmt = "Key is not a valid member of this section. There are %s valid keys: %-(%s, %)";
+
+        if (useColors)
+            formattedWrite(sink, fmt, this.fieldNames.length.paint(Yellow),
+                this.fieldNames.map!(f => f.paint(Green)));
+        else
+            formattedWrite(sink, fmt, this.fieldNames.length, this.fieldNames);
     }
 }

--- a/source/agora/config/Exceptions.d
+++ b/source/agora/config/Exceptions.d
@@ -270,3 +270,22 @@ public class UnknownKeyConfigException : ConfigException
             formattedWrite(sink, fmt, this.fieldNames.length, this.fieldNames);
     }
 }
+
+/// Exception thrown when a required key is missing
+public class MissingKeyException : ConfigException
+{
+    /// Constructor
+    public this (string path, string key, Mark position,
+                 string file = __FILE__, size_t line = __LINE__)
+        @safe pure nothrow @nogc
+    {
+        super(path, key, position, file, line);
+    }
+
+    /// Format the message with or without colors
+    protected override void formatMessage (
+        scope void delegate(in char[]) sink, in FormatSpec!char spec) const scope
+    {
+        sink("Required key was not found in configuration of command line arguments");
+    }
+}

--- a/source/agora/config/Exceptions.d
+++ b/source/agora/config/Exceptions.d
@@ -21,15 +21,6 @@ import dyaml.node;
 import std.algorithm : map;
 import std.format;
 
-/// A convenience wrapper around `enforce` to throw a formatted exception
-package void enforce (E = ConfigExceptionImpl, Args...) (Node node, bool cond,
-                                string fmt, lazy Args args,
-                                string file = __FILE__, size_t line = __LINE__)
-{
-    if (!cond)
-        throw new E(format(fmt, args), node.startMark(), file, line);
-}
-
 /*******************************************************************************
 
     Base exception type thrown by the config parser


### PR DESCRIPTION
This was yet another exploration in meta programming. It took quite a while as there was no tests. We knew the code worked from experience, but no unittest was actually written at the time the library was implemented.

Here is the "main" commit message:
```
    Fix #2: Make usage of colors in error message configurable

    In order for this to be possible, the caller needs to decide whether
    colors are wanted or not, which is done via a custom formatting string.
    This means that we need to encode the format into the Exception
    (with custom Exception types) instead of doing it at the `throw` site.

    This was achieved by the previous commits, introducing an Exception
    type for each kind of error encountered while parsing the config file.
    This, combined with a custom format string, achieve the desired outcome.
    This commit "fixes" the issue, but simply remove the leftover 'enforce'
    method, which is no longer used (as it assumed ahead of time formatting),
    and related utilities.
```

There's still two instance of `enforce`:
```shell
geod24@cpe-172-100-1-244 ~/projects/bpfk/config (git)-[fix-2] % git grep -n 'enforce'
source/agora/config/Config.d:682:            node.enforce(false, "Field '%s' is not optional (first undefined: %s)",
source/agora/config/Config.d:692:        node.enforce(false, "Field '%s' is not optional (first undefined: %s)",
```

They don't compile, but because they are behind a `static if`, and it is never instantiated (or in Agora), it doesn't error out.