### PR TITLE
dub: Add a dummy library configuration

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -10,6 +10,9 @@
 
     "configurations": [
         {
+            "name": "library"
+        },
+        {
             "name": "unittest",
             "dflags": [ "-checkaction=context" ]
         }


### PR DESCRIPTION
Otherwise dub tries to use the 'unittest' configuration all the time,
which results in linker errors when compiling Agora.