### PR TITLE
Change sink type to be '@safe'

### DIFF
--- a/source/agora/config/Utils.d
+++ b/source/agora/config/Utils.d
@@ -19,6 +19,9 @@ module agora.config.Utils;
 
 import std.format;
 
+/// Type of sink used by the `toString`
+package alias SinkType = void delegate (in char[]) @safe;
+
 /*******************************************************************************
 
     Debugging utility for config filler
@@ -80,7 +83,7 @@ package struct Colored (T)
     private T value;
 
     /// Hook for `formattedWrite`
-    public void toString (scope void delegate (in char[]) sink)
+    public void toString (scope SinkType sink)
     {
         static if (is(typeof(T.init.length) : size_t))
             if (this.value.length == 0) return;


### PR DESCRIPTION
```
Trying to update Agora proved tedious, as all sinks in Agora are safe,
meaning the changes required were massive and of no value.
In this case, we decide to break the type system,
because all things considered, it's the less insane thing to do.
```

Tested with Agora: ✅ 