### PR TITLE
Fix HEAD: Don't attempt to catch Throable in safe code

### DIFF
--- a/source/agora/config/Exceptions.d
+++ b/source/agora/config/Exceptions.d
@@ -158,16 +158,19 @@ public abstract class ConfigException : Exception
             if (!this.info)
                 return;
 
-            try
+            () @trusted nothrow
             {
-                sink("\n----------------");
-                foreach (t; info)
+                try
                 {
-                    sink("\n"); sink(t);
+                    sink("\n----------------");
+                    foreach (t; info)
+                    {
+                        sink("\n"); sink(t);
+                    }
                 }
-            }
-            // ignore more errors
-            catch (Throwable) {}
+                // ignore more errors
+                catch (Throwable) {}
+            }();
         }
     }
 


### PR DESCRIPTION
```
For some reason this doesn't trigger an error when the code is unittested,
but does when Agora is being built.
```

I think we're seeing a compiler bug, as in, it should detect the issue, but does not. Anyways, this fixes it for sure.