### PR TITLE
Rename files/modules to match new name

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Let's start with an hello world:
 ```D
 module helloworld;
 
-import agora.config.Config;
+import configy.Read;
 
 import std.stdio;
 import std.typecons;
@@ -78,7 +78,7 @@ This demonstrate a few important properties of the config parser:
 
 ## Full documentation
 
-The full, up-to-date API documentation can be found [here](https://bosagora.github.io/config/).
+The full, up-to-date API documentation can be found [here](https://bosagora.github.io/configy/).
 A list of example for common use cases can be found [here](doc/FAQ.md).
 
 ## Rich error reporting

--- a/dub.json
+++ b/dub.json
@@ -1,5 +1,5 @@
 {
-    "name": "config",
+    "name": "configy",
     "description": "An automatic YAML to struct configuration parser for dlang",
 
     "authors": [ "Mathias 'Geod24' Lang" ],

--- a/examples/helloworld/source/app.d
+++ b/examples/helloworld/source/app.d
@@ -1,6 +1,6 @@
 module helloworld;
 
-import agora.config.Config;
+import configy.Read;
 
 import std.getopt;
 import std.stdio;

--- a/source/configy/Attributes.d
+++ b/source/configy/Attributes.d
@@ -6,7 +6,7 @@
     without importing the whole configuration parsing code.
 
     Copyright:
-        Copyright (c) 2019-2021 BOSAGORA Foundation
+        Copyright (c) 2019-2022 BOSAGORA Foundation
         All rights reserved.
 
     License:
@@ -14,7 +14,7 @@
 
 *******************************************************************************/
 
-module agora.config.Attributes;
+module configy.Attributes;
 
 import core.time;
 import std.conv : to;

--- a/source/configy/Exceptions.d
+++ b/source/configy/Exceptions.d
@@ -3,7 +3,7 @@
     Definitions for Exceptions used by the config module.
 
     Copyright:
-        Copyright (c) 2019-2021 BOSAGORA Foundation
+        Copyright (c) 2019-2022 BOSAGORA Foundation
         All rights reserved.
 
     License:
@@ -11,9 +11,9 @@
 
 *******************************************************************************/
 
-module agora.config.Exceptions;
+module configy.Exceptions;
 
-import agora.config.Utils;
+import configy.Utils;
 
 import dyaml.exception;
 import dyaml.node;

--- a/source/configy/Read.d
+++ b/source/configy/Read.d
@@ -120,7 +120,7 @@
       be processed if it is set to `true`.
 
     Copyright:
-        Copyright (c) 2019-2021 BOSAGORA Foundation
+        Copyright (c) 2019-2022 BOSAGORA Foundation
         All rights reserved.
 
     License:
@@ -128,12 +128,12 @@
 
 *******************************************************************************/
 
-module agora.config.Config;
+module configy.Read;
 
-public import agora.config.Attributes;
-public import agora.config.Exceptions : ConfigException;
-import agora.config.Exceptions;
-import agora.config.Utils;
+public import configy.Attributes;
+public import configy.Exceptions : ConfigException;
+import configy.Exceptions;
+import configy.Utils;
 
 import dyaml.exception;
 import dyaml.node;
@@ -882,7 +882,7 @@ private template FieldRef (alias T, string name)
 {
     // Import needed as `Name` is defined in this template but we also need
     // to use that identifier in `getUDAs`.
-    import agora.config.Attributes : CAName = Name;
+    import configy.Attributes : CAName = Name;
 
     /// The reference to the field
     public alias Ref = __traits(getMember, T, name);

--- a/source/configy/Utils.d
+++ b/source/configy/Utils.d
@@ -7,7 +7,7 @@
     `debug` configuration provided by `dub.json`.
 
     Copyright:
-        Copyright (c) 2019-2021 BOSAGORA Foundation
+        Copyright (c) 2019-2022 BOSAGORA Foundation
         All rights reserved.
 
     License:
@@ -15,7 +15,7 @@
 
 *******************************************************************************/
 
-module agora.config.Utils;
+module configy.Utils;
 
 import std.format;
 


### PR DESCRIPTION
We want to remove any 'agora' name for it to be publicly available.