### PR TITLE
Change SetInfo to default to true when set as a field

### DIFF
--- a/source/configy/Attributes.d
+++ b/source/configy/Attributes.d
@@ -155,8 +155,25 @@ public struct Name
 
 public struct SetInfo (T)
 {
-    /// Allow initialization as a field
-    public this (T initVal, bool isSet = false) @safe pure nothrow @nogc
+    /***************************************************************************
+
+        Allow initialization as a field
+
+        This sets the field as having been set, so that:
+        ```
+        struct Config { SetInfo!Duration timeout; }
+
+        Config myConf = { timeout: 10.minutes }
+        ```
+        Will behave as if set explicitly. If this behavior is not wanted,
+        pass `false` as second argument:
+        ```
+        Config myConf = { timeout: SetInfo!Duration(10.minutes, false) }
+        ```
+
+    ***************************************************************************/
+
+    public this (T initVal, bool isSet = true) @safe pure nothrow @nogc
     {
         this.value = initVal;
         this.set = isSet;

--- a/source/configy/Read.d
+++ b/source/configy/Read.d
@@ -1123,7 +1123,7 @@ unittest
     {
         SetInfo!int value;
         SetInfo!int answer = 42;
-        SetInfo!string name = "Lorene";
+        SetInfo!string name = SetInfo!string("Lorene", false);
 
         SetInfo!Address address;
     }
@@ -1132,7 +1132,7 @@ unittest
     assert(c1.value == 24);
     assert(c1.value.set);
 
-    assert(!c1.answer.set);
+    assert(c1.answer.set);
     assert(c1.answer == 42);
 
     assert(!c1.name.set);


### PR DESCRIPTION
Otherwise, it results in a very confusing behavior for the user,
which has been shown to cause quite a few bugs.