### PR TITLE
Strict mode: Implement soundexer-based key-matching

### DIFF
--- a/source/configy/Test.d
+++ b/source/configy/Test.d
@@ -206,6 +206,8 @@ unittest
     static struct Config
     {
         string value;
+        string valhu;
+        string halvue;
     }
 
     try
@@ -215,7 +217,7 @@ unittest
     }
     catch (ConfigException exc)
     {
-        assert(exc.toString() == "/dev/null(0:0): valeu: Key is not a valid member of this section. There are 1 valid keys: value");
+        assert(exc.toString() == "/dev/null(0:0): valeu: Key is not a valid member of this section. Did you mean: value, valhu");
     }
 }
 


### PR DESCRIPTION
This scales much better, e.g. when using Configy with dub's 54 config keys.

![image](https://user-images.githubusercontent.com/2180215/183262041-96dfc9d6-30c1-4441-93ac-221f195ea995.png)
