### PR TITLE
ConstructionException: Properly print nested Exception, avoid chaining

### DIFF
--- a/source/configy/Exceptions.d
+++ b/source/configy/Exceptions.d
@@ -374,8 +374,9 @@ public class ConstructionException : ConfigException
         scope SinkType sink, in FormatSpec!char spec)
         const scope @trusted
     {
-        // Here we break the type system too, calling a `@system` function,
-        // but since it takes no parameter, why would it not be `@safe` ?
-        sink(this.next.message());
+        if (auto dyn = cast(ConfigException) this.next)
+            dyn.toString(sink, spec);
+        else
+            sink(this.next.message);
     }
 }

--- a/source/configy/Read.d
+++ b/source/configy/Read.d
@@ -830,6 +830,8 @@ private T wrapException (T) (lazy T exp, string path, Mark position,
 {
     try
         return exp;
+    catch (ConfigException exc)
+        throw exc;
     catch (Exception exc)
         throw new ConstructionException(exc, path, position, file, line);
 }

--- a/source/configy/Test.d
+++ b/source/configy/Test.d
@@ -660,3 +660,34 @@ ifaces:
     assert(c.ifaces.length == 2);
     assert(c.ifaces == [ Interface("eth0", "192.168.1.42"), Interface("lo", "127.0.0.42")]);
 }
+
+// Nested ConstructionException
+unittest
+{
+    static struct WillFail
+    {
+        string name;
+        this (string value) @safe pure
+        {
+            throw new Exception("Parsing failed!");
+        }
+    }
+
+    static struct Container
+    {
+        WillFail[] array;
+    }
+
+    static struct Config
+    {
+        Container data;
+    }
+
+    try auto c = parseConfigString!Config(`data:
+  array:
+    - Not
+    - Working
+`, "/dev/null");
+    catch (Exception exc)
+        assert(exc.toString() == `/dev/null(2:6): data.array[0]: Parsing failed!`);
+}


### PR DESCRIPTION
Show the nested ConfigException if it is one, and avoid nesting `ConfigException`
as that would end up printing multiple file/line informations.