### PR TITLE
Make hooks work for the top-level type

### DIFF
--- a/source/configy/Read.d
+++ b/source/configy/Read.d
@@ -407,8 +407,8 @@ public T parseConfig (T) (
                      fullyQualifiedName!T,
                      strict == StrictMode.Warn ?
                        strict.paint(Yellow) : strict.paintIf(!!strict, Green, Red));
-            return node.parseMapping!(StructFieldRef!T)(
-                null, T.init, const(Context)(cmdln, strict), null);
+            return node.parseField!(StructFieldRef!T)(
+                null, T.init, const(Context)(cmdln, strict));
     case NodeID.sequence:
     case NodeID.scalar:
     case NodeID.invalid:

--- a/source/configy/Test.d
+++ b/source/configy/Test.d
@@ -766,3 +766,53 @@ deps:
     assert(c.deps[2] == Package(null, PackageDef("fur", null, 42)));
     assert(c.deps[3] == Package("/one/last/path"));
 }
+
+/// Test top level hook (fromYAML / fromString)
+unittest
+{
+    static struct Version1 {
+        uint fileVersion;
+        uint value;
+    }
+
+    static struct Version2 {
+        uint fileVersion;
+        string str;
+    }
+
+    static struct Config
+    {
+        uint fileVersion;
+        union {
+            Version1 v1;
+            Version2 v2;
+        }
+        static Config fromYAML (scope ConfigParser!Config parser)
+        {
+            static struct OnlyVersion { uint fileVersion; }
+            auto vers = parseConfig!OnlyVersion(
+                CLIArgs.init, parser.node, StrictMode.Ignore);
+            switch (vers.fileVersion) {
+            case 1:
+                return Config(1, parser.parseAs!Version1);
+            case 2:
+                Config conf = Config(2);
+                conf.v2 = parser.parseAs!Version2;
+                return conf;
+            default:
+                assert(0);
+            }
+        }
+    }
+
+    auto v1 = parseConfigString!Config("fileVersion: 1\nvalue: 42", "/dev/null");
+    auto v2 = parseConfigString!Config("fileVersion: 2\nstr: hello world", "/dev/null");
+
+    assert(v1.fileVersion == 1);
+    assert(v1.v1.fileVersion == 1);
+    assert(v1.v1.value == 42);
+
+    assert(v2.fileVersion == 2);
+    assert(v2.v2.fileVersion == 2);
+    assert(v2.v2.str == "hello world");
+}


### PR DESCRIPTION
Before this change, the various hooks (converter, fromYAML, fromString) would only work after one level of recursion.
This was obviously an oversight and is now corrected.