### PR TITLE
Improve support for static arrays and non-CTFEable opEquals

### DIFF
--- a/source/configy/Exceptions.d
+++ b/source/configy/Exceptions.d
@@ -380,3 +380,38 @@ public class ConstructionException : ConfigException
             sink(this.next.message);
     }
 }
+
+/// Thrown when an array read from config does not match a static array size
+public class ArrayLengthException : ConfigException
+{
+    private size_t actual;
+    private size_t expected;
+
+    /// Constructor
+    public this (size_t actual, size_t expected,
+                 string path, string key, Mark position,
+                 string file = __FILE__, size_t line = __LINE__)
+        @safe pure nothrow @nogc
+    {
+        assert(actual != expected);
+        this.actual = actual;
+        this.expected = expected;
+        super(path, key, position, file, line);
+    }
+
+    /// Format the message with or without colors
+    protected override void formatMessage (
+        scope SinkType sink, in FormatSpec!char spec)
+        const scope @trusted
+    {
+        import core.internal.string : unsignedToTempString;
+
+        char[20] buffer = void;
+        sink("Too ");
+        sink((this.actual > this.expected) ? "many" : "few");
+        sink(" entries for sequence: Expected ");
+        sink(unsignedToTempString(this.expected, buffer));
+        sink(", got ");
+        sink(unsignedToTempString(this.actual, buffer));
+    }
+}

--- a/source/configy/FieldRef.d
+++ b/source/configy/FieldRef.d
@@ -68,11 +68,20 @@ package template FieldRef (alias T, string name, bool forceOptional = false)
 
     /// Evaluates to `true` if this field is to be considered optional
     /// (does not need to be present in the YAML document)
-    public enum Optional = forceOptional ||
-        hasUDA!(Ref, CAOptional) ||
-        is(immutable(Type) == immutable(bool)) ||
-        is(Type : SetInfo!FT, FT) ||
-        (Default != Type.init);
+    static if (forceOptional || hasUDA!(Ref, CAOptional))
+        public enum Optional = true;
+    // Booleans are always optional
+    else static if (is(immutable(Type) == immutable(bool)))
+        public enum Optional = true;
+    // A mandatory SetInfo would not make sense
+    else static if (is(Type : SetInfo!FT, FT))
+        public enum Optional = true;
+    // Use `is` to avoid calling `opEquals` which might not be CTFEable,
+    // except for static arrays as that triggers a deprecation warning.
+    else static if (is(Type : E[k], E, size_t k))
+        public enum Optional = (Default[] !is Type.init[]);
+    else
+        public enum Optional = (Default !is Type.init);
 }
 
 unittest

--- a/source/configy/Read.d
+++ b/source/configy/Read.d
@@ -766,13 +766,28 @@ package FR.Type parseField (alias FR)
             if (node.nodeID != NodeID.sequence)
                 throw new TypeConfigException(node, "sequence (array)", path);
 
+            typeof(return) validateLength (E[] res)
+            {
+                static if (is(FR.Type : E_[k], E_, size_t k))
+                {
+                    if (res.length != k)
+                        throw new ArrayLengthException(
+                            res.length, k, path, null, node.startMark());
+                    return res[0 .. k];
+                }
+                else
+                    return res;
+            }
+
             // We pass `E.init` as default value as it is not going to be used:
             // Either there is something in the YAML document, and that will be
             // converted, or `sequence` will not iterate.
-            return node.sequence.enumerate.map!(
+            return validateLength(
+                node.sequence.enumerate.map!(
                 kv => kv.value.parseField!(NestedFieldRef!(E, FR))(
                     format("%s[%s]", path, kv.index), E.init, ctx))
-                .array();
+                .array()
+            );
         }
     }
     else


### PR DESCRIPTION
The original intent of this commit was to avoid calling `opEquals` on types that we were evaluating for optionality, as a simple `is` comparison is enough. However, `is` was not used previously because it triggers a deprecation in D: Doing `a is b` when `a` and `b` are static array would compare their `.ptr`.

Re-writing `isOptional` and adding test yield some issues with static array support, including compilation error. This is now working and the library will throw a proper error if the length do not match.