### PR TITLE
Commit selections file and fix test failure with latest D-YAML

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,9 +21,6 @@ __dummy.html
 docs/
 *-test-library
 *-test-unittest
-# Since this is a library, we ignore `dub.selections.json`.
-# It only matters when used with an application.
-dub.selections.json
 
 # Code coverage
 *.lst

--- a/dub.selections.json
+++ b/dub.selections.json
@@ -1,0 +1,7 @@
+{
+	"fileVersion": 1,
+	"versions": {
+		"dyaml": "0.10.0",
+		"tinyendian": "0.2.0"
+	}
+}

--- a/source/configy/Test.d
+++ b/source/configy/Test.d
@@ -487,7 +487,7 @@ unittest
     }
     catch (ConfigException exc)
     {
-        assert(exc.toString() == "(0:0): chris.jay: Required key was not found in configuration or command line arguments");
+        assert(exc.toString() == "<unknown>(0:0): chris.jay: Required key was not found in configuration or command line arguments", exc.toString());
     }
 }
 


### PR DESCRIPTION
The latest D-YAML slightly changed the behavior of Mark. Note that this should actually print /dev/null but we are simply fixing the test failure now.