### PR TITLE
refactor!: Rename module to not use uppercase

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Let's start with an hello world:
 ```D
 module helloworld;
 
-import configy.Read;
+import configy.read;
 
 import std.stdio;
 import std.typecons;

--- a/examples/helloworld/source/app.d
+++ b/examples/helloworld/source/app.d
@@ -1,6 +1,6 @@
 module helloworld;
 
-import configy.Read;
+import configy.read;
 
 import std.getopt;
 import std.stdio;

--- a/source/configy/attributes.d
+++ b/source/configy/attributes.d
@@ -14,7 +14,7 @@
 
 *******************************************************************************/
 
-module configy.Attributes;
+module configy.attributes;
 
 import std.traits;
 
@@ -298,8 +298,8 @@ public auto converter (FT) (FT func)
 public interface ConfigParser (T)
 {
     import dyaml.node;
-    import configy.FieldRef : StructFieldRef;
-    import configy.Read : Context, parseField;
+    import configy.fieldref : StructFieldRef;
+    import configy.read : Context, parseField;
 
     /// Returns: the node being processed
     public inout(Node) node () inout @safe pure nothrow @nogc;

--- a/source/configy/exceptions.d
+++ b/source/configy/exceptions.d
@@ -11,9 +11,9 @@
 
 *******************************************************************************/
 
-module configy.Exceptions;
+module configy.exceptions;
 
-import configy.Utils;
+import configy.utils;
 
 import dyaml.exception;
 import dyaml.node;

--- a/source/configy/fieldref.d
+++ b/source/configy/fieldref.d
@@ -15,10 +15,10 @@
 
 *******************************************************************************/
 
-module configy.FieldRef;
+module configy.fieldref;
 
 // Renamed imports as the names exposed by `FieldRef` shadow the imported ones.
-import configy.Attributes : CAName = Name, CAOptional = Optional, SetInfo;
+import configy.attributes : CAName = Name, CAOptional = Optional, SetInfo;
 
 import std.meta;
 import std.traits;
@@ -86,7 +86,7 @@ package template FieldRef (alias T, string name, bool forceOptional = false)
 
 unittest
 {
-    import configy.Attributes : Name;
+    import configy.attributes : Name;
 
     static struct Config1
     {

--- a/source/configy/read.d
+++ b/source/configy/read.d
@@ -141,13 +141,13 @@
 
 *******************************************************************************/
 
-module configy.Read;
+module configy.read;
 
-public import configy.Attributes;
-public import configy.Exceptions : ConfigException;
-import configy.Exceptions;
-import configy.FieldRef;
-import configy.Utils;
+public import configy.attributes;
+public import configy.exceptions : ConfigException;
+import configy.exceptions;
+import configy.fieldref;
+import configy.utils;
 
 import dyaml.exception;
 import dyaml.node;

--- a/source/configy/test.d
+++ b/source/configy/test.d
@@ -11,12 +11,12 @@
 
 *******************************************************************************/
 
-module configy.Test;
+module configy.test;
 
-import configy.Attributes;
-import configy.Exceptions;
-import configy.Read;
-import configy.Utils;
+import configy.attributes;
+import configy.exceptions;
+import configy.read;
+import configy.utils;
 
 import dyaml.node;
 

--- a/source/configy/utils.d
+++ b/source/configy/utils.d
@@ -15,7 +15,7 @@
 
 *******************************************************************************/
 
-module configy.Utils;
+module configy.utils;
 
 import std.format;
 


### PR DESCRIPTION
The official D style recommends that module name be all lowercase. We've had this exception when under internal development, but now that the project is in dlang-community, it should follow best practices.