### PR TITLE
Add parsing of pointers

### DIFF
--- a/source/configy/fieldref.d
+++ b/source/configy/fieldref.d
@@ -73,6 +73,9 @@ package template FieldRef (alias T, string name, bool forceOptional = false)
     // Booleans are always optional
     else static if (is(immutable(Type) == immutable(bool)))
         public enum Optional = true;
+    // Same for pointers
+    else static if (is(immutable(Type) == immutable(T*), T))
+        public enum Optional = true;
     // A mandatory SetInfo would not make sense
     else static if (is(Type : SetInfo!FT, FT))
         public enum Optional = true;

--- a/source/configy/read.d
+++ b/source/configy/read.d
@@ -822,6 +822,13 @@ package FR.Type parseField (alias FR)
             );
         }
     }
+    else static if (is(FR.Type == T*, T))
+    {
+        // Allocate and parse pointers' values.
+        // This allows us to have recursive types. Pointers are always optional.
+        // If the type needs to be mandatory, it should be declared as a value.
+        return [node.parseField!(NestedFieldRef!(T, FR))(path, T.init, ctx)].ptr;
+    }
     else
     {
         static assert (!is(FR.Type == union),

--- a/source/configy/test.d
+++ b/source/configy/test.d
@@ -986,3 +986,21 @@ ds:
     catch (ConfigException exc)
         assert(exc.toString() == "/dev/null(1:11): es.enabled: Expected to be a value of type bool, but is a scalar");
 }
+
+/// Test pointers
+unittest
+{
+    static struct N {
+        @Optional int value;
+        const N* left, right;
+    }
+    auto c = parseConfigString!N(`left:
+  left:
+    value: 1
+right:
+  value: 2
+`, "/dev/null");
+    assert(c.left.left.value == 1);
+    assert(c.left.right is null);
+    assert(c.right.value == 2);
+}


### PR DESCRIPTION
Pointers can be useful if we want to allow using types recursively directly (i.e. not as an array or mapping), for example to express tree structures (decision trees, composite types, etc.).