### PR TITLE
Allow parsing scalars and mappings into the same type

### DIFF
--- a/source/configy/attributes.d
+++ b/source/configy/attributes.d
@@ -350,11 +350,12 @@ public struct Only (string[] Values) {
 
     alias value this;
 
-    public static Only fromString (scope string str) {
+    public static Only fromYAML (scope ConfigParser!Only cp) {
         import std.algorithm.searching : canFind;
         import std.exception : enforce;
         import std.format;
 
+        scope str = cp.parseAs!string;
         enforce(Values.canFind(str),
             "%s is not a valid value for this field, valid values are: %(%s, %)"
             .format(str, Values));

--- a/source/configy/read.d
+++ b/source/configy/read.d
@@ -737,7 +737,14 @@ package FR.Type parseField (alias FR)
     }
 
     else static if (hasFromString!(FR.Type))
-        return wrapConstruct(FR.Type.fromString(node.parseScalar!(string)(path)), path, node.location());
+    {
+        if (auto mapping = node.asMapping())
+            return mapping.parseMapping!(FR)(path, defaultValue, ctx, null);
+        else if (auto scalar = node.asScalar())
+            return wrapConstruct(FR.Type.fromString(scalar.str), path, node.location());
+        else
+            throw new TypeConfigException(node, "a mapping (object) or a scalar", path);
+    }
 
     else static if (hasStringCtor!(FR.Type))
         return wrapConstruct(FR.Type(node.parseScalar!(string)(path)), path, node.location());

--- a/tests/unit/configy/yaml.d
+++ b/tests/unit/configy/yaml.d
@@ -839,6 +839,38 @@ unittest
     assert(v2.v2.str == "hello world");
 }
 
+/// Test calling fromString on scalars only
+unittest
+{
+    static struct Job {
+        static struct Image {
+            string name;
+            bool force_pull;
+            static Image fromString(string s) {
+                Image v;
+                v.name = s;
+                return v;
+            }
+        }
+        Image image;
+    }
+    struct Config { Job job; }
+
+    auto c1 = parseConfigString!Config(`
+job:
+  image: ruby:3.0
+`, "/dev/null");
+    auto c2 = parseConfigString!Config(`
+job:
+  image:
+    name: ruby:3.0
+    force_pull: true
+`, "/dev/null");
+    assert(c1.job.image.name == "ruby:3.0");
+    assert(c2.job.image.name == "ruby:3.0");
+    assert(c2.job.image.force_pull);
+}
+
 /// Don't call `opCmp` / `opEquals` as they might not be CTFEable
 /// Also various tests around static arrays
 unittest


### PR DESCRIPTION
Some YAML schemas seem to support specifying values either as a single string, or as a dictionary.

One practical example is the `image` option in `.gitlab-ci.yml` files:

https://docs.gitlab.com/ee/ci/yaml/#image

GitLab accepts either

```yaml
test-job:
  image: ruby:3.0
```

or

```yaml
test-job:
  image:
    name: ruby:3.0
```

This change enables us to support this functionality, by calling `fromString` only on scalar nodes; mappings are deserialized as usual.