### PR TITLE
configy: Catch and re-throw validation errors

### DIFF
--- a/source/configy/read.d
+++ b/source/configy/read.d
@@ -653,7 +653,7 @@ private TLFR.Type parseMapping (alias TLFR)
             {
                 dbgWrite("%s: Calling `%s` method",
                      TLFR.Type.stringof.paint(Cyan), "validate()".paint(Green));
-                result.validate();
+                wrapConstruct(result.validate(), path, Location.get(node));
             }
             else
             {

--- a/source/configy/test.d
+++ b/source/configy/test.d
@@ -332,11 +332,22 @@ unittest
         public int value;
     }
 
+    static struct ThrowingValidate
+    {
+        void validate() const
+        {
+            throw new Exception("Bad data, try again");
+        }
+
+        public int value;
+    }
+
     static struct InnerConfig
     {
         public int value;
         @Optional ThrowingCtor ctor;
         @Optional ThrowingFromString fromString;
+        @Optional ThrowingValidate validated;
 
         @Converter!int(
             (Node value) {
@@ -372,6 +383,16 @@ unittest
     catch (ConfigException exc)
     {
         assert(exc.toString() == "/dev/null(2:14): config.fromString: Some meaningful error message");
+    }
+
+    try
+    {
+        auto result = parseConfigString!Config("config:\n  value: 42\n  validated:\n    value: 42", "/dev/null");
+        assert(0);
+    }
+    catch (ConfigException exc)
+    {
+        assert(exc.toString() == "/dev/null(3:4): config.validated: Bad data, try again");
     }
 
     try


### PR DESCRIPTION
The documentation states:

> If validation of individual fields is not enough and the section as
> a whole needs to be validated, one can implement a void validate()
> const method which throws an exception in the even of a validation
> failure. **The library will rethrow this Exception with the
> file/line information pointing to the section itself, and not any
> individual field.**

The emphasized section was not actually implemented - exceptions thrown from validate() functions bubbled up to the top level and were printed without any context.

Fix this by implementing the functionality.