### PR TITLE
feat!: Implement multi-backend support, including split-files and environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ docs/
 
 # Examples binary
 examples/helloworld/helloworld
+examples/full/myapp

--- a/examples/full/dub.json
+++ b/examples/full/dub.json
@@ -1,0 +1,6 @@
+{
+    "name": "myapp",
+    "dependencies": {
+        "configy": { "path": "../../", "version": "*" }
+    }
+}

--- a/examples/full/dub.selections.json
+++ b/examples/full/dub.selections.json
@@ -1,0 +1,8 @@
+{
+	"fileVersion": 1,
+	"versions": {
+		"configy": {"path":"../../"},
+		"dyaml": "0.10.0",
+		"tinyendian": "0.2.0"
+	}
+}

--- a/examples/full/myconfig.yaml
+++ b/examples/full/myconfig.yaml
@@ -1,0 +1,3 @@
+attendee:
+    - name: John Doe
+    - name: Jany Dirkin

--- a/examples/full/source/app.d
+++ b/examples/full/source/app.d
@@ -1,0 +1,67 @@
+module helloworld;
+
+import configy.easy;
+
+import std.stdio;
+import std.typecons;
+
+struct FriendConfig
+{
+    string name;
+    @Optional int age;
+}
+
+struct Config
+{
+    string user;
+    SetInfo!int frequency;
+    FriendConfig witness;
+    FriendConfig[] attendee;
+}
+
+int main (string[] clargs)
+{
+    // This will read `args` (and modify it a la `getopt`), look up `config.yaml`,
+    // and the environment using the binary name as prefix.
+    CLIArgs args;
+    args.parse(clargs);
+    Nullable!Config configN = parseAppConfiguration!Config(args);
+    if (configN.isNull())
+        return 1;
+    auto config = configN.get();
+
+    writeln("Configuration: ", config);
+
+    // From environment (`MYAPP_USER`)
+    assert(config.user == "John Smith");
+    // From the command line
+    assert(config.frequency == 42);
+    assert(config.frequency.set == true);
+
+    // Name comes from arg, age from env
+    assert(config.witness == FriendConfig("Kevin Bacon", 121));
+
+    // From the configuration file
+    assert(config.attendee.length == 2);
+    assert(config.attendee[0] == FriendConfig("John Doe"));
+    assert(config.attendee[1] == FriendConfig("Jany Dirkin", 27));
+
+    assert(clargs == [ "./myapp", "some", "positional", "arguments" ]);
+
+    return 0;
+}
+
+private ConfigT parseAppConfiguration (ConfigT) (in CLIArgs args)
+{
+    import configy.backend.arguments;
+    import configy.backend.environment;
+    import configy.backend.multi;
+    import configy.backend.node;
+    import configy.backend.yaml;
+
+    Mapping args_root = ArgumentBackend.make(args.overrides);
+    Mapping env_root = EnvironmentBackend.make(`MYAPP`);
+    Mapping yaml_root = parseFile(args.config_path);
+    scope root = MultiBackend.make([args_root, env_root, yaml_root]);
+    return parseConfig!ConfigT(root);
+}

--- a/examples/full/test.sh
+++ b/examples/full/test.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/bash
+
+export MYAPP_USER="John Smith"
+# Will be overriden by CLI
+export MYAPP_FREQUENCY=32
+# Will be overriden by CLI
+export MYAPP_WITNESS_NAME="Solomon"
+export MYAPP_WITNESS_AGE=121
+
+exec dub run -- some -O witness.name="Kevin Bacon" positional -O frequency=42 arguments -c myconfig.yaml

--- a/source/configy/backend/arguments.d
+++ b/source/configy/backend/arguments.d
@@ -1,0 +1,36 @@
+/*******************************************************************************
+
+    Backend to look up configuration values in command-line arguments
+
+    This backend implements a convention to read values for configuration
+    entries using a command-line convention. The default usage in Configy is
+    to provide them via `-O`, e.g. `-O foo.bar.value=42`. For a different
+    convention, one may extend this backend to their own needs.
+
+*******************************************************************************/
+
+module configy.backend.arguments;
+
+import configy.backend.keyvalue;
+
+/// This struct simply acts as a namespace to simplify importing multiple backends
+public struct ArgumentBackend {
+    /***************************************************************************
+
+        Get a mapping representing the list of command-line overrides
+
+        The returned value is a `Mapping` that will represent values in the
+        configuration.
+
+        Params:
+          args = The list of overrides that have been provided via CLI
+
+        Returns:
+          The root node for the argument backend, as a `Mapping`.
+
+    ***************************************************************************/
+
+    public static KeyValueMapping make (const string[][string] args) @safe pure nothrow {
+        return new KeyValueMapping(null, args, '.');
+    }
+}

--- a/source/configy/backend/environment.d
+++ b/source/configy/backend/environment.d
@@ -1,0 +1,65 @@
+/*******************************************************************************
+
+    Backend to look up configuration values in environment variables
+
+    This backend implement a convention to map configuration values to
+    environment variables. It is much more limited than other backend due to
+    the fact that environment variables are simply key/value strings.
+
+    The backend expects a prefix to be used, to avoid configuration values
+    being pulled from unexpected places for very generic name. For example,
+    if there is a `home` scalar at the top level, that would pull `$HOME`
+    without a prefix, while the user probably intends to use `MYAPP_HOME`.
+
+    Scalar are easily represented as environment variables are strings. However,
+    hierarchy (and hence mapping) is usually denoted by separating keys with
+    an underscore. For example, the following configuration:
+    ```
+    struct User { string name; }
+    struct Config {
+      User user;
+    }
+    ```
+    will map to the environment variable (assuming `CONFIGY` prefix):
+    `CONFIGY_USER_NAME`. Sequences currently are not supported.
+
+*******************************************************************************/
+
+module configy.backend.environment;
+
+import configy.backend.keyvalue;
+
+/// This struct simply acts as a namespace to simplify importing multiple backends
+public struct EnvironmentBackend {
+    import std.process;
+
+    /***************************************************************************
+
+        Get a mapping representing the environment
+
+        The returned value is a `Mapping` that will represent values in the
+        environment. Changes to the environment will not be picked up. If a
+        prefix is provided (recommended), only values matching the prefix will
+        be taken into account.
+
+        Params:
+          prefix = If present, the prefix will be used by Configy as a top level
+                   namespace. For example, if `MYAPP` is provided, and the
+                   config has a nested `foo` struct with a `bar` field, Configy
+                   will look for `MYAPP_FOO_BAR`, whether with an empty prefix
+                   it will simply look for `FOO_BAR`. It is recommended to use
+                   a prefix whenever possible.
+          env = The environment to use. If not provided,
+                `std.process : environment` will be used.
+
+        Returns:
+          The root node for the environment, as a `Mapping`.
+
+    ***************************************************************************/
+
+    public static KeyValueMapping make (string prefix, const string[string] env = environment.toAA())
+         @safe pure nothrow {
+        prefix = prefix.length ? (prefix ~ '_') : null;
+        return new KeyValueMapping(prefix, env, '_');
+    }
+}

--- a/source/configy/backend/keyvalue.d
+++ b/source/configy/backend/keyvalue.d
@@ -1,0 +1,211 @@
+/*******************************************************************************
+
+    A generic key-value backend to allow associating path to values
+
+    This backend allows translating a path to a key name that can then be
+    looked up. It is useful for use case like environment variable or command
+    line argument.
+
+*******************************************************************************/
+
+module configy.backend.keyvalue;
+
+import configy.backend.node;
+
+import std.algorithm;
+import std.range : takeOne;
+import std.uni : icmp, toLower;
+
+/**
+ * Represents a mapping over a key-value pair.
+ *
+ * A mapping is essentially a filter over a list of keys. For example, if the
+ * available values are `home.user`, home.address`, `location.altitude`, using
+ * the filter `home` will have 2 values in scope, while `location` would have
+ * one and `foo` would have none.
+ *
+ * This also apply to environment variables, where names are usually uppercase
+ * and the separator is `_`. This prefix is stored in `KeyValueMapping`, along
+ * with the entire list of key-values, which allow us to avoid duplicating
+ * (and hence allocating) it for every lookup.
+ */
+public class KeyValueMapping : Mapping {
+    /// The prefix (ending with a separator) that keys must match to
+    /// be considered to be in this mapping
+    private string prefix;
+
+    /// The separator used for keys
+    private char separator;
+
+    /// The entire (unfiltered) list of key-value
+    private const string[][string] values;
+
+    /***************************************************************************
+
+        Creates a new KeyValueMapping
+
+        Params:
+          prefix = Prefix to apply to this mapping. May be `null`.
+          values = The entire list of values to use.
+          separator = The separator the applies to `prefix`.
+
+    ***************************************************************************/
+
+    public this (string prefix, const string[][string] values, char separator)
+        @safe pure nothrow @nogc {
+        this.separator = separator;
+        this.values = values;
+        this.prefix = prefix;
+        assert(!this.prefix.length || this.prefix[$-1] == this.separator);
+    }
+
+    /// Ditto
+    public this (string prefix, inout const string[][string] values, char separator)
+        inout @safe pure nothrow @nogc {
+        this.separator = separator;
+        this.values = values;
+        this.prefix = prefix;
+        assert(!this.prefix.length || this.prefix[$-1] == this.separator);
+    }
+
+    ///
+    public this (string prefix, const string[string] values, char separator)
+        @safe pure nothrow {
+        import std.array;
+        import std.typecons;
+        this(prefix, values.byKeyValue.map!(kv => tuple(kv.key, [ kv.value])).assocArray, separator);
+    }
+
+    ///
+    public size_t length () const scope @safe {
+        return this.values.byKey.filter!(k => k.startsWith(this.prefix)).count();
+    }
+
+    /// Iterates over this object, passing each entry to the `dg`
+    public int opApply (scope MapIterator dg) scope {
+        foreach (kv; this.values.byKeyValue()) {
+            if (!kv.key.startsWith(this.prefix)) continue;
+            const kname = this.getKeyNames(kv.key);
+            scope kn = new SimpleScalar(kname[0].toLower(), Location.init);
+            // If kname[1] is not empty, then it is still a mapping.
+            // This still needs to be here to allow for scope allocation
+            int res;
+            if (kname[1].length) {
+                const offset = this.prefix.length + kname[0].length + 1;
+                res = this.withNewMapping(this.getPrefix(kv.key, offset),
+                    (scope KeyValueMapping vn) => dg(kn, vn),
+                );
+            } else {
+                scope vn = new SequenceOrScalar(kv.value, Location(kv.key));
+                res = dg(kn, vn);
+            }
+            if (res) return res;
+        }
+        return 0;
+    }
+
+    /// Here so we can get a scope instance of the right type
+    private int withNewMapping (this KVM) (string prefix,
+        scope int delegate(scope KeyValueMapping nmap) dg) scope {
+        // Cast to string qualifier as we always want a mutable instance
+        alias MutableKVM = typeof(cast()KVM.init);
+        scope nmap = new MutableKVM(prefix, this.values, this.separator);
+        return dg(nmap);
+    }
+
+    /// Here to get a long-lived instance of the right type
+    private KVM newMapping (this KVM) (string prefix) scope {
+        return new KVM(prefix, this.values, this.separator);
+    }
+
+    public override Location location () const scope @safe nothrow {
+        return Location(this.prefix.length ? this.prefix[0 .. $ - 1] : null);
+    }
+    public override Type type () const scope @safe nothrow { return Type.Mapping; }
+    public override inout(KeyValueMapping) asMapping () inout scope @safe { return this; }
+    public override inout(Sequence) asSequence () inout scope @safe { return null; }
+    public override inout(Scalar) asScalar () inout scope @safe { return null; }
+
+    /***************************************************************************
+
+        Utility function to get the name of a 'key' in a mapping
+
+        Returns:
+          An array of two element, the current key value and the next key value.
+
+    ***************************************************************************/
+
+    protected string[2] getKeyNames (string value) const scope @safe {
+        assert(value.length >= this.prefix.length);
+        auto rng = value[this.prefix.length .. $].splitter(this.separator);
+        if (rng.empty)
+            return [null, null];
+        const current = rng.front;
+        rng.popFront();
+        return [current, !rng.empty ? rng.front : null];
+    }
+
+    unittest {
+        string[][string] empty;
+        scope env = new KeyValueMapping("CONFIGY_", empty, '_');
+        assert(env.getKeyNames("CONFIGY_HOME_USER")      == ["HOME", "USER"]);
+        env.prefix = "CONFIGY_HOME_";
+        assert(env.getKeyNames("CONFIGY_HOME_USER") == ["USER", null]);
+
+        env.separator = '.';
+        env.prefix = null;
+        assert(env.getKeyNames("home.user") == ["home", "user"]);
+        env.prefix = "home.";
+        assert(env.getKeyNames("home.user") == ["user", null]);
+    }
+
+    /// Returns: A new prefix to use, without allocating
+    protected string getPrefix (string variable, size_t offset)
+        const scope @safe pure nothrow @nogc {
+        assert(offset < variable.length);
+        return variable[0 .. offset + (variable[offset] == this.separator)];
+    }
+}
+
+///
+public class SequenceOrScalar : Sequence, Scalar {
+    /// The actual data
+    private const string[] values;
+    /// Location of the variable
+    private Location loc;
+
+    ///
+    public this (const string[] values, Location loc) @safe pure nothrow @nogc {
+        this.values = values;
+        this.loc = loc;
+    }
+
+    ///
+    public override int opApply(scope SeqIterator dg) scope {
+        foreach (idx, value; this.values) {
+            scope val = new SimpleScalar(value, this.loc);
+            if (auto res = dg(idx, val))
+                return res;
+        }
+        return 0;
+    }
+
+    ///
+    public override string str () const return scope @safe {
+        return this.values.length ? this.values[$-1] : null;
+    }
+
+    ///
+    public override size_t length () const scope @safe { return this.values.length; }
+
+    ///
+    public override Location location () const scope @safe nothrow { return this.loc; }
+    ///
+    public override Type type () const scope @safe nothrow { return Type.Sequence; }
+    ///
+    public override inout(Mapping) asMapping () inout scope @safe { return null; }
+    ///
+    public override inout(SequenceOrScalar) asSequence () inout scope @safe { return this; }
+    ///
+    public override inout(SequenceOrScalar) asScalar () inout scope @safe { return this; }
+}

--- a/source/configy/backend/multi.d
+++ b/source/configy/backend/multi.d
@@ -1,0 +1,143 @@
+/*******************************************************************************
+
+    A backend that is composed of multiple backends
+
+    This can be used for a variety of purposes: to have Configy parse the
+    content of multiple files at once, with the first file having priorities
+    over the values, to add overrides, such as environment variables
+    or command-line arguments, or even to compose multiple formats.
+
+*******************************************************************************/
+
+module configy.backend.multi;
+
+import configy.backend.node;
+
+import std.algorithm;
+import std.exception;
+
+/// This struct simply acts as a namespace to simplify importing multiple backends
+public struct MultiBackend {
+
+    /***************************************************************************
+
+        Get a mapping proxying multiple mappings
+
+        A `MultiMapping` will simply wrap another set of mappings and iterate on
+        their values, in the order of their parent nodes being passed to this
+        function.
+
+        Params:
+          nodes = The nodes to wrap (highest priority first).
+
+        Returns:
+          The root node for the `MultiMapping`.
+
+    ***************************************************************************/
+
+    public static MultiMapping make (Mapping[] nodes) @safe {
+        assert(nodes.length > 0, "No nodes passed to MultiBackend");
+        return new MultiMapping(nodes);
+    }
+}
+
+
+///
+public class MultiMapping : Mapping {
+    /// The underlying nodes
+    protected Mapping[] nodes;
+
+    ///
+    public this (Mapping[] nodes) @safe pure nothrow @nogc {
+        assert(nodes.length);
+        this.nodes = nodes;
+    }
+
+    ///
+    public override Type type () const scope @safe nothrow {
+        return Type.Mapping;
+    }
+
+    ///
+    public override Location location () const scope @safe nothrow {
+        return this.nodes[0].location();
+    }
+
+    ///
+    public override inout(Mapping)  asMapping () inout scope @safe { return this; }
+    public override inout(Sequence) asSequence () inout scope @safe { return null; }
+    public override inout(Scalar)   asScalar () inout scope @safe   { return null; }
+
+    /// Returns: The length of this object (the number of entries in it)
+    public size_t length () const scope @safe {
+        return this.nodes[0].length();
+    }
+
+    /// Iterates over this object, passing each entry to the `dg`
+    public int opApply (scope MapIterator dg) scope {
+        enforce(this.nodes.length < typeof(MultiMappingBuffer.buffer).length,
+            "Having more than 256 backends is not supported");
+
+        foreach (idx, n; this.nodes) {
+            foreach (scope key, scope value; n) {
+                auto kv = enforce(key.asScalar(), "Key is not a value");
+                // Skip over keys that have been previously visited
+                if (this.nodes[0 .. idx].any!(n => n.has(kv.str)))
+                    continue;
+
+                if (auto m = value.asMapping()) {
+                    // If the value is a mapping, we need to wrap it in a `MultiMapping`,
+                    // otherwise mapping will not be properly merged.
+                    // Since some backend might not allocate, we have to recurse to fill
+                    // a static array.
+                    MultiMappingBuffer buff;
+                    if (int res = buff.accumulate(kv, this.nodes[idx .. $], dg))
+                        return res;
+                } else {
+                    if (int res = dg(key, value))
+                        return res;
+                }
+            }
+        }
+        return 0;
+    }
+}
+
+/**
+ * An utility buffer to accumulate Mapping into
+ *
+ * When we iterate over a mapping and encounter another mapping, we need to
+ * recurse and instantiate a MultiMapping wrapper so that nodes get properly
+ * merged. To make this possible without allocating or branching too much,
+ * we use this struct to give us a static buffer, and skip empty (null) nodes.
+ */
+private struct MultiMappingBuffer {
+    /// The underlying buffer
+    private Mapping[256] buffer;
+    /// Our position in the buffer
+    private size_t idx;
+
+    /// Adds a node to the buffer - skip any `null` node
+    public void add (scope Mapping node) @safe scope return {
+        if (node is null) return;
+        this.buffer[this.idx++] = node;
+    }
+
+    /// Returns: A slice of the buffer with all non-null node
+    public Mapping[] opSlice () @safe scope return {
+        return this.buffer[0 .. this.idx];
+    }
+
+    /// Accumulate all sub-mapping of `nodes` that have key `key`,
+    /// then call `resolve` with a `MultiMapping` wrapping them.
+    private int accumulate (scope Scalar key, scope Mapping[] nodes, scope Mapping.MapIterator resolve) {
+        if (!nodes.length) {
+            scope mm = new MultiMapping(this[]);
+            return resolve(key, mm);
+        }
+        return nodes[0].withNode(key.str(), (scope Node k, scope Node v) {
+            this.add(v ? v.asMapping() : null);
+            return this.accumulate(key, nodes[1 .. $], resolve);
+        });
+    }
+}

--- a/source/configy/backend/node.d
+++ b/source/configy/backend/node.d
@@ -189,3 +189,35 @@ public RT withNode (DGT : RT function(scope Node, scope Node), RT)
 public bool has (scope Mapping map, string key) {
     return map.withNode(key, (scope Node key, scope Node value) => value !is null);
 }
+
+/// A 'simple' scalar implementation, which only contains a name and a value.
+public class SimpleScalar : Scalar {
+    /// The actual data
+    private string value;
+    /// Location of the variable
+    private Location loc;
+
+    /// Construct an instance of this class
+    public this (string value, Location loc) inout @safe pure nothrow @nogc {
+        this.value = value;
+        this.loc = loc;
+    }
+    /// Ditto
+    public this (string value, Location loc) @safe pure nothrow @nogc {
+        this.value = value;
+        this.loc = loc;
+    }
+
+    ///
+    public override string str () const scope return @safe { return this.value; }
+    ///
+    public override Location location () const scope @safe nothrow { return this.loc; }
+    ///
+    public override Type type () const scope @safe nothrow { return Type.Scalar; }
+    ///
+    public override inout(Mapping) asMapping () inout scope @safe { return null; }
+    ///
+    public override inout(Sequence) asSequence () inout scope @safe { return null; }
+    ///
+    public override inout(SimpleScalar) asScalar () inout scope @safe { return this; }
+}

--- a/tests/unit/configy/environment.d
+++ b/tests/unit/configy/environment.d
@@ -1,0 +1,51 @@
+/*******************************************************************************
+
+    Contains tests related to MultiBackend (e.g. different combination)
+
+    Copyright:
+        Copyright (c) 2019-2025 Mathias Lang
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+module configy.test.environment;
+
+import configy.attributes;
+import configy.exceptions;
+import configy.read;
+import configy.utils;
+import configy.backend.environment;
+import configy.backend.node;
+
+import std.format;
+
+/// Test EnvironmentBackend
+unittest {
+    static struct ClientConfig {
+        string host;
+        ushort port;
+    }
+
+    static struct Config {
+        ClientConfig local;
+        ClientConfig production;
+    }
+
+    scope n1 = EnvironmentBackend.make(`CONFIGY`, [
+        `CLIENT`: `ignored`,
+        `CONFIGY_LOCAL_HOST`: `http://localhost/`,
+        `CONFIGY_LOCAL_PORT`: `587`,
+        `CONFIGY_PRODUCTION_HOST`: `http://remote/`,
+        `CONFIGY_PRODUCTION_PORT`: `666`,
+        `SERVER`: `Also ignored`,
+    ]);
+
+    const result = parseConfig!Config(n1);
+    assert(result.local.host == `http://localhost/`);
+    assert(result.local.port == 587);
+    assert(result.production.host == `http://remote/`);
+    assert(result.production.port == 666);
+}

--- a/tests/unit/configy/multi.d
+++ b/tests/unit/configy/multi.d
@@ -1,0 +1,269 @@
+/*******************************************************************************
+
+    Contains tests related to MultiBackend (e.g. different combination)
+
+    Copyright:
+        Copyright (c) 2019-2025 Mathias Lang
+        All rights reserved.
+
+    License:
+        MIT License. See LICENSE for details.
+
+*******************************************************************************/
+
+module configy.test.multi;
+
+import configy.attributes;
+import configy.exceptions;
+import configy.read;
+import configy.utils;
+import configy.backend.environment;
+import configy.backend.multi;
+import configy.backend.node;
+import configy.backend.yaml;
+
+import std.format;
+
+/// Test MultiBackend internals (no call to parseConfig)
+unittest {
+    auto n1 = parseString(`l1:
+  l2:
+    name: "John"
+j1:
+  j2:
+    name: "Henry"
+    age: 42
+`, `/etc/node1`).asMapping();
+    assert(n1 !is null);
+
+    auto n2 = parseString(`l1:
+  l2:
+    name: "Fred"
+    age: 24
+j1:
+  j2:
+    age: 28
+`, `/etc/node2`).asMapping();
+    assert(n2 !is null);
+
+    auto n3 = parseString(`l1:
+  l2:
+    name: "Brian"
+`, `/etc/node3`).asMapping();
+    assert(n3 !is null);
+
+    scope root = MultiBackend.make([n3, n2, n1]);
+    size_t tlCount;
+    foreach (scope key, scope value; root) {
+        ++tlCount;
+        const k = key.asScalar().str;
+        assert(k == "l1" || k == "j1");
+    }
+    assert(tlCount == 2,
+        "We iterated more than twice at the top level");
+}
+
+/// Simple MultiBackend test with two incomplete nodes
+unittest {
+    static struct ClientConfig {
+        bool enabled = true;
+        int[] peers;
+    }
+
+    static struct ServerConfig {
+        bool enabled = true;
+        string greeting;
+    }
+
+    static struct Config {
+        ClientConfig client;
+        ServerConfig server;
+    }
+
+    auto n1 = parseString(`client:
+  enabled: true
+  peers:
+    - 42
+    - 84
+server:
+  enabled: false`, `/etc/node1`).asMapping();
+    assert(n1 !is null);
+
+    auto n2 = parseString(`client:
+  enabled: false
+server:
+    enabled: true
+    greeting: "Hello World"`, `/etc/node2`).asMapping();
+    assert(n2 !is null);
+
+    // n1 takes precedence
+    {
+        scope root = MultiBackend.make([n1, n2]);
+        const result = parseConfig!Config(root);
+        assert(result.client.enabled);
+        assert(result.client.peers == [42, 84]);
+        assert(!result.server.enabled);
+        assert(!result.server.greeting.length);
+    }
+
+    // n2 takes precedence
+    {
+        scope root = MultiBackend.make([n2, n1]);
+        const result = parseConfig!Config(root);
+        assert(!result.client.enabled);
+        assert(!result.client.peers.length);
+        assert(result.server.enabled);
+        assert(result.server.greeting == "Hello World");
+    }
+}
+
+/// Test partially specified nested node across three backends
+unittest {
+    static struct LevelTwo {
+        string name;
+        int age;
+    }
+    static struct LevelOne {
+        LevelTwo l2;
+        LevelTwo j2;
+    }
+    static struct Config {
+        LevelOne l1;
+        LevelOne j1;
+        LevelOne o1 = LevelOne(LevelTwo("Default", 11), LevelTwo("D2", 22));
+    }
+
+    auto n1 = parseString(`l1:
+  l2:
+    name: "John"
+  j2:
+    age: 111
+j1:
+  l2:
+    name: "Bruce"
+  j2:
+    name: "Henry"
+    age: 42
+`, `/etc/node1`).asMapping();
+    assert(n1 !is null);
+
+    auto n2 = parseString(`l1:
+  l2:
+    name: "Fred"
+    age: 24
+  j2:
+    name: "Chabal"
+j1:
+  l2:
+    age: 666
+  j2:
+    age: 28
+`, `/etc/node2`).asMapping();
+    assert(n2 !is null);
+
+    auto n3 = parseString(`l1:
+  l2:
+    name: "Brian"
+`, `/etc/node3`).asMapping();
+    assert(n3 !is null);
+
+    scope root = MultiBackend.make([n3, n2, n1]);
+    const result = parseConfig!Config(root);
+
+    assert(result.l1.l2.name == "Brian");
+    assert(result.l1.l2.age == 24);
+    assert(result.j1.j2.name == "Henry");
+    assert(result.j1.j2.age == 28);
+}
+
+/// Test EnvironmentBackend combined with YAMLBackend
+unittest {
+    static struct ClientConfig {
+        bool enabled = true;
+        int value;
+    }
+
+    static struct ServerConfig {
+        bool enabled = true;
+        string greeting;
+    }
+
+    static struct Config {
+        ClientConfig client;
+        ServerConfig server;
+        ServerConfig backup;
+    }
+
+    scope n1 = EnvironmentBackend.make(`CONFIGY`, [
+        `CLIENT`: `ignored`,
+        `CONFIGY_SERVER_ENABLED`: `false`,
+        `SERVER`: `Also ignored`,
+        `CONFIGY_CLIENT_VALUE`: `42`,
+        `CONFIGY_BACKUP_ENABLED`: `false`,
+        `XDF_HOME_DIRECTORY`: `/home/root/`,
+    ]);
+    scope Mapping n2 = parseString(`backup:
+  enabled: true
+  greeting: "Out of Memory"`, `/etc/node1`)
+        .asMapping();
+    assert(n2 !is null);
+    {
+        scope root = MultiBackend.make([n1, n2]);
+        const result = parseConfig!Config(root);
+        assert(result.client.enabled);
+        assert(result.client.value == 42);
+        assert(!result.server.enabled);
+        assert(!result.server.greeting.length);
+        assert(!result.backup.enabled);
+        assert(!result.backup.greeting.length);
+    }
+
+    {
+        scope root = MultiBackend.make([n2, n1]);
+        const result = parseConfig!Config(root);
+        assert(result.client.enabled);
+        assert(result.client.value == 42);
+        assert(!result.server.enabled);
+        assert(!result.server.greeting.length);
+        assert(result.backup.enabled);
+        assert(result.backup.greeting == `Out of Memory`);
+
+    }
+}
+
+/// Behavior of enabled: The value provided always override
+/// the default.
+unittest {
+    static struct PeerConfig {
+        bool enabled = true;
+        string name;
+    }
+
+    static struct Config {
+        PeerConfig peer;
+    }
+
+    auto n1 = parseString(`peer:
+  enabled: false`, `/etc/node1`).asMapping();
+    assert(n1 !is null);
+
+    auto n2 = parseString(`peer:
+  name: "This will be ignored"`, `/etc/node2`).asMapping();
+    assert(n2 !is null);
+
+    // n1 takes precedence
+    {
+        scope root = MultiBackend.make([n1, n2]);
+        const result = parseConfig!Config(root);
+        assert(!result.peer.enabled);
+        assert(!result.peer.name.length);
+    }
+
+    // n2 takes precedence but doesn't set `enabled`
+    {
+        scope root = MultiBackend.make([n2, n1]);
+        const result = parseConfig!Config(root);
+        assert(!result.peer.enabled);
+        assert(!result.peer.name.length);
+    }
+}


### PR DESCRIPTION
This is a massive change that I've been wanting to do for a while. It will allow to cover all the missing use cases we have (read from env & CLI override).

Not ready for merge yet. Need
1) A lot more tests;
2) To be split up a bit;
3) Support for an "override" backend (what CLIArgs was supposed to do);
4) Clear up some code artifacts - E.g. the notion of backend and factory were from an earlier iteration which has been simplified;