### PR TITLE
refactor!: Remove Mapping.opBinaryRight!in

### DIFF
--- a/source/configy/backend/node.d
+++ b/source/configy/backend/node.d
@@ -66,11 +66,6 @@ public interface Mapping : Node {
     /// Iterates over this object, passing each entry to the `dg`
     public int opApply (scope MapIterator dg) scope;
 
-    /// Returns: a `Node` if `key` is present in `this`, `null` otherwise
-    public inout(Node) opBinaryRight(string op : "in")(string key) inout scope return @safe {
-        return this.lookup(key);
-    }
-
     /// Ditto
     public inout(Node) lookup (string key) inout scope return @safe;
 }

--- a/source/configy/read.d
+++ b/source/configy/read.d
@@ -588,7 +588,7 @@ private TLFR.Type parseMapping (alias TLFR)
             dbgWrite("Found %s (%s.%s) in `fieldDefaults`",
                      FR.Name.paint(Cyan), path.paint(Cyan), FR.FieldName.paint(Cyan));
 
-            if (ctx.strict && FR.FieldName in node)
+            if (ctx.strict && node.lookup(FR.FieldName))
                 throw new ConfigExceptionImpl("'Key' field is specified twice",
                     path.addPath(FR.FieldName), node.location());
             return (*ptr).parseField!(FR)(path.addPath(FR.FieldName), default_, ctx)
@@ -596,7 +596,7 @@ private TLFR.Type parseMapping (alias TLFR)
                              FR.FieldName.paint(Cyan));
         }
 
-        if (auto value = FR.Name in node)
+        if (auto value = node.lookup(FR.Name))
         {
             dbgWrite("%s: YAML field is %s in node%s",
                      FR.Name.paint(Cyan), "present".paint(Green),
@@ -1031,13 +1031,13 @@ private EnabledState isMappingEnabled (M) (Mapping node, string path, auto ref M
                        "`enabled` field `" ~ EMT[0].FieldName ~
                        "` conflicts with `disabled` field `" ~ DMT[0].FieldName ~ "`");
 
-        if (auto n = "enabled" in node)
+        if (auto n = node.lookup("enabled"))
             return EnabledState(EnabledState.Field.Enabled, n.parseScalar!(bool)(path.addPath("enabled")));
         return EnabledState(EnabledState.Field.Enabled, __traits(getMember, default_, EMT[0].FieldName));
     }
     else static if (DMT.length)
     {
-        if (auto n = "disabled" in node)
+        if (auto n = node.lookup("disabled"))
             return EnabledState(EnabledState.Field.Disabled, n.parseScalar!(bool)(path.addPath("disabled")));
         return EnabledState(EnabledState.Field.Disabled, __traits(getMember, default_, DMT[0].FieldName));
     }

--- a/tests/unit/configy/yaml.d
+++ b/tests/unit/configy/yaml.d
@@ -1027,7 +1027,7 @@ unittest {
 
         static Config fromYAML(scope ConfigParser!Config parser) {
             auto mapping = parser.node.asMapping();
-            const typeN = mapping ? "type" in mapping : null;
+            const typeN = mapping ? mapping.lookup("type") : null;
             // This will point to the start of the file / section
             enforce(typeN, "Missing required 'type' property");
             auto scalar = typeN.asScalar();


### PR DESCRIPTION
This is a leftover of the previous implementation (YAML only) and forces one to return a node, while we want to take a different approach.