### PR TITLE
refactor(read): Move higher-level API to an 'easy' module

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Let's start with an hello world:
 ```D
 module helloworld;
 
-import configy.read;
+import configy.easy;
 
 import std.stdio;
 import std.typecons;

--- a/examples/helloworld/source/app.d
+++ b/examples/helloworld/source/app.d
@@ -1,6 +1,6 @@
 module helloworld;
 
-import configy.read;
+import configy.easy;
 
 import std.getopt;
 import std.stdio;

--- a/source/configy/attributes.d
+++ b/source/configy/attributes.d
@@ -365,7 +365,7 @@ public struct Only (string[] Values) {
 ///
 unittest {
     import configy.attributes : Only, Optional;
-    import configy.read : parseConfigString;
+    import configy.easy : parseConfigString;
 
     static struct CountryConfig {
         Only!(["France", "Malta", "South Korea"]) country;

--- a/source/configy/easy.d
+++ b/source/configy/easy.d
@@ -1,0 +1,196 @@
+/*******************************************************************************
+
+    Provide the suggested default configuration for applications
+
+    This module provide the basic tool to quickly get configuration parsing with
+    environment and command-line overrides. It assumes a YAML configuration.
+
+    Note:
+      This module name is inspired inspired by cURL's 'easy' API.
+
+*******************************************************************************/
+
+module configy.easy;
+
+public import configy.attributes;
+public import configy.exceptions : ConfigException;
+public import configy.read;
+
+import std.getopt;
+import std.typecons : Nullable, nullable;
+
+/// Command-line arguments
+public struct CLIArgs
+{
+    /// Path to the config file
+    public string config_path = "config.yaml";
+
+    /// Overrides for config options
+    public string[][string] overrides;
+
+    /// Helper to add items to `overrides`
+    public void overridesHandler (string, string value)
+    {
+        import std.string;
+        const idx = value.indexOf('=');
+        if (idx < 0) return;
+        string k = value[0 .. idx], v = value[idx + 1 .. $];
+        if (auto val = k in this.overrides)
+            (*val) ~= v;
+        else
+            this.overrides[k] = [ v ];
+    }
+
+    /***************************************************************************
+
+        Parses the base command line arguments
+
+        This can be composed with the program argument.
+        For example, consider a program which wants to expose a `--version`
+        switch, the definition could look like this:
+        ---
+        public struct ProgramCLIArgs
+        {
+            public CLIArgs base; // This struct
+
+            public alias base this; // For convenience
+
+            public bool version_; // Program-specific part
+        }
+        ---
+        Then, an application-specific configuration routine would be:
+        ---
+        public GetoptResult parse (ref ProgramCLIArgs clargs, ref string[] args)
+        {
+            auto r = clargs.base.parse(args);
+            if (r.helpWanted) return r;
+            return getopt(
+                args,
+                "version", "Print the application version, &clargs.version_");
+        }
+        ---
+
+        Params:
+          args = The command line args to parse (parsed options will be removed)
+          passThrough = Whether to enable `config.passThrough` and
+                        `config.keepEndOfOptions`. `true` by default, to allow
+                        composability. If your program doesn't have other
+                        arguments, pass `false`.
+
+        Returns:
+          The result of calling `getopt`
+
+    ***************************************************************************/
+
+    public GetoptResult parse (ref string[] args, bool passThrough = true)
+    {
+        return getopt(
+            args,
+            // `caseInsensistive` is the default, but we need something
+            // with the same type for the ternary
+            passThrough ? config.keepEndOfOptions : config.caseInsensitive,
+            // Also the default, same reasoning
+            passThrough ? config.passThrough : config.noPassThrough,
+            "config|c",
+                "Path to the config file. Defaults to: " ~ this.config_path,
+                &this.config_path,
+
+            "override|O",
+                "Override a config file value\n" ~
+                "Example: -O foo.bar=true -O dns=1.1.1.1 -O dns=2.2.2.2\n" ~
+                "Array values are additive, other items are set to the last override",
+                &this.overridesHandler,
+        );
+    }
+}
+
+/*******************************************************************************
+
+    Attempt to read and process the config file at `path`, print any error
+
+    This 'simple' overload of the more detailed `parseConfigFile` will attempt
+    to read the file at `path`, and return a `Nullable` instance of it.
+    If an error happens, either because the file isn't readable or
+    the configuration has an issue, a message will be printed to `stderr`,
+    with colors if the output is a TTY, and a `null` instance will be returned.
+
+    The calling code can hence just read a config file via:
+    ```
+    int main ()
+    {
+        auto configN = parseConfigFileSimple!Config("config.yaml");
+        if (configN.isNull()) return 1; // Error path
+        auto config = configN.get();
+        // Rest of the program ...
+    }
+    ```
+    An overload accepting `CLIArgs args` also exists.
+
+    Params:
+        path = Path of the file to read from
+        args = Command line arguments on which `parse` has been called
+        strict = Whether the parsing should reject unknown keys in the
+                 document, warn, or ignore them (default: `StrictMode.Error`)
+
+    Returns:
+        An initialized `Config` instance if reading/parsing was successful;
+        a `null` instance otherwise.
+
+*******************************************************************************/
+
+public Nullable!T parseConfigFileSimple (T) (string path, StrictMode strict = StrictMode.Error)
+{
+    return wrapException(parseConfigFile!(T)(CLIArgs(path), strict));
+}
+
+/// Ditto
+public Nullable!T parseConfigFileSimple (T) (in CLIArgs args, StrictMode strict = StrictMode.Error)
+{
+    return wrapException(parseConfigFile!(args, strict));
+}
+
+/*******************************************************************************
+
+    Parses the config file or string and returns a `Config` instance.
+
+    Params:
+        cmdln = command-line arguments (containing the path to the config)
+        path = When parsing a string, the path corresponding to it
+        strict = Whether the parsing should reject unknown keys in the
+                 document, warn, or ignore them (default: `StrictMode.Error`)
+
+    Throws:
+        `Exception` if parsing the config file failed.
+
+    Returns:
+        `Config` instance
+
+*******************************************************************************/
+
+public T parseConfigFile (T)
+    (in CLIArgs cmdln, StrictMode strict = StrictMode.Error)
+{
+    import configy.backend.yaml;
+
+    auto root = parseFile(cmdln.config_path);
+    return parseConfig!T(root, strict);
+}
+
+/// ditto
+public T parseConfigString (T)
+    (string data, string path, StrictMode strict = StrictMode.Error)
+{
+    CLIArgs cmdln = { config_path: path };
+    return parseConfigString!(T)(data, cmdln, strict);
+}
+
+/// ditto
+public T parseConfigString (T)
+    (string data, in CLIArgs cmdln, StrictMode strict = StrictMode.Error)
+{
+    import configy.backend.yaml;
+
+    assert(cmdln.config_path.length, "No config_path provided to parseConfigString");
+    auto root = parseString(data, cmdln.config_path);
+    return parseConfig!T(root, strict);
+}

--- a/source/configy/read.d
+++ b/source/configy/read.d
@@ -1,13 +1,14 @@
 /*******************************************************************************
 
     Utilities to fill a struct representing the configuration with the content
-    of a YAML document.
+    of a document.
 
-    The main function of this module is `parseConfig`. Convenience functions
-    `parseConfigString` and `parseConfigFile` are also available.
+    The main function of this module is `parseConfig`. Higher-level wrappers
+    such as `parseConfigString` and `parseConfigFile` are also available in
+    `configy.easy`.
 
     The type parameter to those three functions must be a struct and is used
-    to drive the processing of the YAML node. When an error is encountered,
+    to drive the processing of the mapping. When an error is encountered,
     an `Exception` will be thrown, with a descriptive message.
     The rules by which the struct is filled are designed to be
     as intuitive as possible, and are described below.
@@ -63,7 +64,7 @@
     Duration_parsing:
       If the config field is of type `core.time.Duration`, special parsing rules
       will apply. There are two possible forms in which a Duration field may
-      be expressed. In the first form, the YAML node should be a mapping,
+      be expressed. In the first form, the node should be a mapping,
       and it will be checked for fields matching the supported units
       in `core.time`: `weeks`, `days`, `hours`, `minutes`, `seconds`, `msecs`,
       `usecs`, `hnsecs`, `nsecs`. Strict parsing option will be respected.
@@ -88,7 +89,7 @@
       underscore ('_'), followed by a unit name as defined in `core.time`.
       This can be either the field name directly, or a name override.
       The latter is recommended to avoid confusion when using the field in code.
-      In this form, the YAML node is expected to be a scalar.
+      In this form, the node is expected to be a scalar.
       So the previous example, using this form, would be expressed as:
       ---
       sleepFor_minutes: 510
@@ -107,8 +108,8 @@
 
     Strict_Parsing:
       When strict parsing is enabled, the config filler will also validate
-      that the YAML nodes do not contains entry which are not present in the
-      mapping (struct) being processed.
+      that the mappings do not contains entry which are not present in the
+      struct being processed.
       This can be useful to catch typos or outdated configuration options.
 
     Post_Validation:
@@ -202,7 +203,7 @@ public Nullable!T wrapException (T) (lazy T parseCall)
     }
     catch (Exception exc)
     {
-        // Other Exception type may be thrown by D-YAML,
+        // Other Exception type may be thrown by the underlying libraries.
         // they won't include rich information.
         stderr.writeln(exc.message());
         return typeof(return).init;
@@ -235,8 +236,8 @@ private void printException (scope ConfigException exc) @trusted
 
 /*******************************************************************************
 
-    Process the content of the YAML document described by `node` into an
-    instance of the struct `T`.
+    Process the content of the document described by `node` into an instance of
+    the struct `T`.
 
     See the module description for a complete overview of this function.
 
@@ -278,7 +279,7 @@ public T parseConfig (T) (Node node, StrictMode strict = StrictMode.Error)
 
 /*******************************************************************************
 
-    The behavior to have when encountering a field in YAML not present
+    The behavior to have when encountering a field in the document not present
     in the config definition.
 
 *******************************************************************************/
@@ -306,7 +307,7 @@ package struct Context
 
     Params:
       TLFR = Top level field reference for this mapping
-      node = The YAML node object matching the struct being read
+      node = The node object matching the struct being read
       path = The runtime path to this mapping, used for nested types
       defaultValue = The default value to use for `T`, which can be different
                      from `T.init` when recursing into fields with initializers.
@@ -368,7 +369,7 @@ private TLFR.Type parseMapping (alias TLFR)
     auto convertField (alias FR) ()
     {
         static if (FR.Name != FR.FieldName)
-            dbgWrite("Field name `%s` will use YAML field `%s`",
+            dbgWrite("Field name `%s` will use document field `%s`",
                      FR.FieldName.paint(Yellow), FR.Name.paint(Green));
         // Using exact type here matters: we could get a qualified type
         // (e.g. `immutable(string)`) if the field is qualified,
@@ -408,11 +409,11 @@ private TLFR.Type parseMapping (alias TLFR)
         return node.withNode(FR.Name, (scope Node key, scope Node value) {
             if (value !is null)
             {
-                dbgWrite("%s: YAML field is %s in node%s",
+                dbgWrite("%s: document field is %s in node%s",
                     FR.Name.paint(Cyan), "present".paint(Green),
                     (FR.Name == FR.FieldName ? "" : " (note that field name is overriden)").paint(Yellow));
                 return value.parseField!(FR)(path.addPath(FR.Name), default_, ctx)
-                    .dbgWriteRet("Using value '%s' from YAML document for field '%s'",
+                    .dbgWriteRet("Using value '%s' from document for field '%s'",
                         FR.FieldName.paint(Cyan));
             }
 
@@ -512,7 +513,7 @@ private TLFR.Type parseMapping (alias TLFR)
     Parse a field, trying to match up the compile-time expectation with
     the run time value of the Node (`Node.Type`).
 
-    This is the central point which does "type conversion", from the YAML node
+    This is the central point which does "type conversion", from the node
     to the field type. Whenever adding support for a new type, things should
     happen here.
 
@@ -646,7 +647,7 @@ package FR.Type parseField (alias FR)
             }
 
             // We pass `E.init` as default value as it is not going to be used:
-            // Either there is something in the YAML document, and that will be
+            // Either there is something in the document, and that will be
             // converted, or `sequence` will not iterate.
             E[] result;
             foreach (size_t idx, scope Node value; seq)
@@ -745,7 +746,7 @@ private struct DurationMapping
     ///
     public void validate () const @safe
     {
-        // That check should never fail, as the YAML parser would error out,
+        // That check should never fail, as the document parser would error out,
         // but better be safe than sorry.
         foreach (field; this.tupleof)
             if (field.set)

--- a/source/configy/read.d
+++ b/source/configy/read.d
@@ -143,158 +143,24 @@
 
 module configy.read;
 
-public import configy.attributes;
-public import configy.exceptions : ConfigException;
+import configy.attributes;
+import configy.exceptions : ConfigException;
 import configy.exceptions;
 import configy.fieldref;
 import configy.utils;
 import configy.backend.node;
 
-import dyaml.exception;
-static import YN = dyaml.node;
-
 import std.algorithm;
 import std.conv;
 import std.datetime;
 import std.format;
-import std.getopt;
 import std.meta;
 import std.range;
 import std.stdio;
 import std.traits;
-import std.typecons : Nullable, nullable, tuple;
+import std.typecons : Nullable, nullable;
 
 static import core.time;
-
-/// Command-line arguments
-public struct CLIArgs
-{
-    /// Path to the config file
-    public string config_path = "config.yaml";
-
-    /// Overrides for config options
-    public string[][string] overrides;
-
-    /// Helper to add items to `overrides`
-    public void overridesHandler (string, string value)
-    {
-        import std.string;
-        const idx = value.indexOf('=');
-        if (idx < 0) return;
-        string k = value[0 .. idx], v = value[idx + 1 .. $];
-        if (auto val = k in this.overrides)
-            (*val) ~= v;
-        else
-            this.overrides[k] = [ v ];
-    }
-
-    /***************************************************************************
-
-        Parses the base command line arguments
-
-        This can be composed with the program argument.
-        For example, consider a program which wants to expose a `--version`
-        switch, the definition could look like this:
-        ---
-        public struct ProgramCLIArgs
-        {
-            public CLIArgs base; // This struct
-
-            public alias base this; // For convenience
-
-            public bool version_; // Program-specific part
-        }
-        ---
-        Then, an application-specific configuration routine would be:
-        ---
-        public GetoptResult parse (ref ProgramCLIArgs clargs, ref string[] args)
-        {
-            auto r = clargs.base.parse(args);
-            if (r.helpWanted) return r;
-            return getopt(
-                args,
-                "version", "Print the application version, &clargs.version_");
-        }
-        ---
-
-        Params:
-          args = The command line args to parse (parsed options will be removed)
-          passThrough = Whether to enable `config.passThrough` and
-                        `config.keepEndOfOptions`. `true` by default, to allow
-                        composability. If your program doesn't have other
-                        arguments, pass `false`.
-
-        Returns:
-          The result of calling `getopt`
-
-    ***************************************************************************/
-
-    public GetoptResult parse (ref string[] args, bool passThrough = true)
-    {
-        return getopt(
-            args,
-            // `caseInsensistive` is the default, but we need something
-            // with the same type for the ternary
-            passThrough ? config.keepEndOfOptions : config.caseInsensitive,
-            // Also the default, same reasoning
-            passThrough ? config.passThrough : config.noPassThrough,
-            "config|c",
-                "Path to the config file. Defaults to: " ~ this.config_path,
-                &this.config_path,
-
-            "override|O",
-                "Override a config file value\n" ~
-                "Example: -O foo.bar=true -O dns=1.1.1.1 -O dns=2.2.2.2\n" ~
-                "Array values are additive, other items are set to the last override",
-                &this.overridesHandler,
-        );
-    }
-}
-
-/*******************************************************************************
-
-    Attempt to read and process the config file at `path`, print any error
-
-    This 'simple' overload of the more detailed `parseConfigFile` will attempt
-    to read the file at `path`, and return a `Nullable` instance of it.
-    If an error happens, either because the file isn't readable or
-    the configuration has an issue, a message will be printed to `stderr`,
-    with colors if the output is a TTY, and a `null` instance will be returned.
-
-    The calling code can hence just read a config file via:
-    ```
-    int main ()
-    {
-        auto configN = parseConfigFileSimple!Config("config.yaml");
-        if (configN.isNull()) return 1; // Error path
-        auto config = configN.get();
-        // Rest of the program ...
-    }
-    ```
-    An overload accepting `CLIArgs args` also exists.
-
-    Params:
-        path = Path of the file to read from
-        args = Command line arguments on which `parse` has been called
-        strict = Whether the parsing should reject unknown keys in the
-                 document, warn, or ignore them (default: `StrictMode.Error`)
-
-    Returns:
-        An initialized `Config` instance if reading/parsing was successful;
-        a `null` instance otherwise.
-
-*******************************************************************************/
-
-public Nullable!T parseConfigFileSimple (T) (string path, StrictMode strict = StrictMode.Error)
-{
-    return wrapException(parseConfigFile!(T)(CLIArgs(path), strict));
-}
-
-/// Ditto
-Nullable!T parseConfigFileSimple (T) (in CLIArgs args, StrictMode strict = StrictMode.Error)
-{
-    return wrapException(parseConfigFile!(args, strict));
-}
 
 /*******************************************************************************
 
@@ -369,52 +235,6 @@ private void printException (scope ConfigException exc) @trusted
 
 /*******************************************************************************
 
-    Parses the config file or string and returns a `Config` instance.
-
-    Params:
-        cmdln = command-line arguments (containing the path to the config)
-        path = When parsing a string, the path corresponding to it
-        strict = Whether the parsing should reject unknown keys in the
-                 document, warn, or ignore them (default: `StrictMode.Error`)
-
-    Throws:
-        `Exception` if parsing the config file failed.
-
-    Returns:
-        `Config` instance
-
-*******************************************************************************/
-
-public T parseConfigFile (T)
-    (in CLIArgs cmdln, StrictMode strict = StrictMode.Error)
-{
-    import configy.backend.yaml;
-
-    auto root = parseFile(cmdln.config_path);
-    return parseConfig!T(root, strict);
-}
-
-/// ditto
-public T parseConfigString (T)
-    (string data, string path, StrictMode strict = StrictMode.Error)
-{
-    CLIArgs cmdln = { config_path: path };
-    return parseConfigString!(T)(data, cmdln, strict);
-}
-
-/// ditto
-public T parseConfigString (T)
-    (string data, in CLIArgs cmdln, StrictMode strict = StrictMode.Error)
-{
-    import configy.backend.yaml;
-
-    assert(cmdln.config_path.length, "No config_path provided to parseConfigString");
-    auto root = parseString(data, cmdln.config_path);
-    return parseConfig!T(root, strict);
-}
-
-/*******************************************************************************
-
     Process the content of the YAML document described by `node` into an
     instance of the struct `T`.
 
@@ -422,7 +242,6 @@ public T parseConfigString (T)
 
     Params:
       T = Type of the config struct to fill
-      cmdln = Command line arguments (deprecated)
       node = The root node matching `T`
       strict = Action to take when encountering unknown keys in the document
 
@@ -435,14 +254,6 @@ public T parseConfigString (T)
 
 *******************************************************************************/
 
-deprecated("Use the overload that doesn't use `CLIArgs` as first argument")
-public T parseConfig (T) (
-    in CLIArgs cmdln, Node node, StrictMode strict = StrictMode.Error)
-{
-    return parseConfig!T(node, strict);
-}
-
-/// Ditto
 public T parseConfig (T) (Node node, StrictMode strict = StrictMode.Error)
 {
     static assert(is(T == struct), "`" ~ __FUNCTION__ ~
@@ -463,12 +274,6 @@ public T parseConfig (T) (Node node, StrictMode strict = StrictMode.Error)
     case Node.Type.Invalid:
         throw new TypeConfigException(node, "a mapping (object)", "document root");
     }
-}
-
-deprecated("Use the overload that accepts a `configy.backend.Node : Node`")
-public T parseConfig (T) (
-    in CLIArgs cmdln, YN.Node node, StrictMode strict = StrictMode.Error) {
-    return parseConfig!T(nodeFactory(node), strict);
 }
 
 /*******************************************************************************

--- a/tests/unit/configy/yaml.d
+++ b/tests/unit/configy/yaml.d
@@ -14,8 +14,8 @@
 module configy.test.yaml;
 
 import configy.attributes;
+import configy.easy;
 import configy.exceptions;
-import configy.read;
 import configy.utils;
 import configy.backend.node;
 import configy.backend.yaml;


### PR DESCRIPTION
```
This allows us to separate the lower-level 'read' API from the higher-level,
application and (still) YAML-focused higher level API.
Most users should reach for the easy API, and consider 'read' as a building block.

This removes the last dependency that 'read' had on the YAML-specific parts.
```