### PR TITLE
fix(read): Improve handling of Key UDA for empty mapping

### DIFF
--- a/source/configy/backend/yaml.d
+++ b/source/configy/backend/yaml.d
@@ -182,7 +182,7 @@ public final class YAMLScalar : YAMLNode, Scalar {
 
     ///
     public override string str () const scope return @safe {
-        return this.n.as!string;
+        return this.n.type() == YN.NodeType.null_ ? null : this.n.as!string;
     }
 }
 

--- a/source/configy/read.d
+++ b/source/configy/read.d
@@ -614,16 +614,29 @@ package FR.Type parseField (alias FR)
             string key = getUDAs!(FR.Ref, Key)[0].name;
             E[] result;
             foreach (scope Node k, scope Node value; mapping) {
+                scope npath = path.addPath(k.parseScalar!string(path));
                 if (scope vmap = value.asMapping()) {
-                    result ~= vmap.parseMapping!(StructFieldRef!E)(
-                        path.addPath(k.parseScalar!string(path)),
+                    result ~= vmap.parseMapping!(StructFieldRef!E)(npath,
                         E.init, ctx, key.length ? [ key: k ] : null);
+                    continue;
                 }
-                else
-                    throw new TypeConfigException(
-                        "sequence of " ~ value.type().toString(),
-                        "sequence of mapping (array of objects)",
-                        path, node.location());
+                // It might be a single entry, e.g.
+                // ---
+                // values:
+                // morevalues:
+                //   key: value
+                // ---
+                // In this instance, `values` is an empty mapping but might be
+                // interpreted as a scalar.
+                if (scope scalar = value.asScalar())
+                    if (scalar.str is null) {
+                        scope emptyNode = new EmptyNode(value.location());
+                        result ~= emptyNode.parseMapping!(StructFieldRef!E)(npath,
+                            E.init, ctx, key.length ? [ key: k ] : null);
+                        continue;
+                    }
+                throw new TypeConfigException(value.type().toString(), "mapping",
+                    npath, value.location());
             }
             return result;
         }

--- a/tests/unit/configy/yaml.d
+++ b/tests/unit/configy/yaml.d
@@ -1054,3 +1054,51 @@ unittest {
     const servicename = service.conf.match!((JobConfig jc) => assert(0), (ServiceConfig sc) => sc.name);
     assert(servicename == "dns");
 }
+
+unittest {
+    static struct ImageConfig {
+        // Only this field is required
+        public string name;
+        public string containerfile = "Containerfile";
+        public @Optional string[] tags;
+    }
+
+    static struct ImageConfig2 {
+        // Both fields are required
+        public string name;
+        public string file;
+    }
+
+    static struct Config {
+        public @Optional @Key("name") ImageConfig[]  images;
+        public @Optional @Key("name") ImageConfig2[] images2;
+    }
+
+    auto c = parseConfigString!Config(`images:
+  foo/bar/root:
+    containerfile: path/Containerfile
+    tags: [ "latest" ]
+  far/boo/runner:
+`, "/dev/null");
+
+    assert(c.images[0].name == "foo/bar/root");
+    assert(c.images[0].containerfile == "path/Containerfile");
+    assert(c.images[1].name == "far/boo/runner");
+
+    try parseConfigString!Config(`images:
+  foo/bar/root:
+    containerfile: path/Containerfile
+    tags: [ "latest" ]
+  far/boo/runner: [ 1, 2, 3]
+`, "/dev/null");
+    catch (ConfigException exc)
+        assert(exc.toString() == "/dev/null(5:19): images.far/boo/runner: Expected to be mapping, but is a sequence");
+
+        try parseConfigString!Config(`images2:
+  foo/bar/root:
+    file: path/Containerfile
+  far/boo/runner:
+`, "/dev/null");
+    catch (ConfigException exc)
+        assert(exc.toString() == "/dev/null(4:18): images2.far/boo/runner.file: Required key was not found in configuration or command line arguments");
+}


### PR DESCRIPTION
There were several issues uncovered by those test cases:
- The path and location information of the error message pointed to the parent node, not the node that was triggering an error. So if the error was for the 5th entry in a list, the user would be unhelpfully and confusingly pointed to the beginning of the list and not the offending node;
- Getting a YAML scalar node that was null would return 'null', not a D null value; This might need to be handled differently in the future if we need to distinguish between actual null and empty strings;
- Finally, empty mapping are parsed as null scalar by default by D-YAML, which makes sense as D-YAML does not know what structure to expect, but we do, so we need to explicitly handle the null case as an empty object;