### PR TITLE
feat(read): Rename `fromYAML` hook to `fromConfig` and remove templating on ConfigParser

### DIFF
--- a/doc/FAQ.md
+++ b/doc/FAQ.md
@@ -193,15 +193,15 @@ or 87030 seconds.
 
 The library recognizes three possible ways (hooks) where a field of type `T`,
 where `T` is a `struct`, can be constructed:
-- The `T` has a `static` `fromYAML` method which accepts as sole non-default
-  argument is a `configy.attributes : ConfigParser!T`;
+- The `T` has a `static` `fromConfig` method which accepts as sole non-default
+  argument is a `configy.attributes : ConfigParser`;
 - The `T` has a `static` `fromString` method which accepts a single argument
   that is a string-like type (e.g. `scope const char[]` or just `string`),
   and returns an instance of a type that implicitly converts to `T`;
 - `T` has an explicitly-defined constructor that accepts, as a single parameter,
   a string-like type;
 
-If more than one option exists, the `fromYAML` hook will be preferred,
+If more than one option exists, the `fromConfig` hook will be preferred,
 followed by the `fromString` and finally the constructor.
 Otherwise, the library will default to field-wise construction.
 
@@ -306,7 +306,7 @@ It is also trivial to implement such a type if a project has specific needs.
 
 ### Implement really custom logic that Configy doesn't support
 
-Use the `fromYAML` static method:
+Use the `fromConfig` static method:
 ```
 struct Service { string name; }
 struct ServiceConfig {
@@ -324,7 +324,7 @@ struct JobConfig {
 struct Config {
     SumType!(ServiceConfig, JobConfig) conf;
 
-    static Config fromYAML(scope ConfigParser!Config parser) {
+    static Config fromConfig (scope ConfigParser parser) {
         const typeN = "type" in parser.node;
         // This will point to the start of the file / section
         enforce(typeN, "Missing required 'type' property");

--- a/doc/rationale.md
+++ b/doc/rationale.md
@@ -22,7 +22,7 @@ one could support arbitrary section names with an associative array, but it woul
 done with `@Key("nameField")`.
 
 For such cases that fall outside of Configy's expectations, one may always "drop down"
-to using hooks (such as `fromString` or `fromYAML`) to implement any custom logic.
+to using hooks (such as `fromString` or `fromConfig`) to implement any custom logic.
 
 ## Data vs Identity
 
@@ -56,16 +56,16 @@ which is a problem for every configuration file.
 
 When designing a config format, even for internal schema, it might be useful to
 have types that are external, such as library types (be it Phobos, Vibe.d, or another).
-Those types are unlikely to have `fromYAML` support, and hence might need to be wrapped
+Those types are unlikely to have `fromConfig` support, and hence might need to be wrapped
 in another project-controlled type to be present in the configuration struct. To avoid
 needless wrapping, Configy supports the most common construction protocols: field-wise
 constructor (the default constructor), string constructor, or `fromString`. Anything
-else is likely to require a wrapping type that uses one of those methods, or `fromYAML`.
+else is likely to require a wrapping type that uses one of those methods, or `fromConfig`.
 
 ## Escape hatch
 
 In order to support both external schema, and unforeseen internal schema use cases,
-Configy provides a powerful escape hatch in the form of the `static` `fromYAML`
+Configy provides a powerful escape hatch in the form of the `static` `fromConfig`
 method. In order to avoid losing all the convenience of Configy once one "drops down"
 to that level, the `ConfigParser` exposes a `parseAs` method which allows one to
 recurse into the regular Configy parsing.

--- a/source/configy/attributes.d
+++ b/source/configy/attributes.d
@@ -189,18 +189,16 @@ public struct SetInfo (T)
 
 /*******************************************************************************
 
-    Interface that is passed to `fromYAML` hook
+    Interface that is passed to `fromConfig` hook
 
-    The `ConfigParser` exposes the raw YAML node (`see `node` method),
+    The `ConfigParser` exposes the raw underlying node (see `node` method),
     the path within the file (`path` method), and a simple ability to recurse
-    via `parseAs`.
-
-    Params:
-      T = The type of the structure which defines a `fromYAML` hook
+    via `parseAs`. This allows to implement complex logic independent of the
+    underlying configuration format.
 
 *******************************************************************************/
 
-public interface ConfigParser (T)
+public interface ConfigParser
 {
     import configy.backend.node;
     import configy.fieldref : StructFieldRef;
@@ -217,7 +215,7 @@ public interface ConfigParser (T)
         Parse this struct as another type
 
         This allows implementing union-like behavior, where a `struct` which
-        implements `fromYAML` can parse a simple representation as one type,
+        implements `fromConfig` can parse a simple representation as one type,
         and one more advanced as another type.
 
         Params:

--- a/source/configy/read.d
+++ b/source/configy/read.d
@@ -22,18 +22,6 @@
       To mark a field as optional even with its default value,
       use the `Optional` UDA: `@Optional int count = 0;`.
 
-    fromYAML:
-      Because config structs may contain complex types outside of the project's
-      control (e.g. a Phobos type, Vibe.d's `URL`, etc...) or one may want
-      the config format to be more dynamic (e.g. by exposing union-like behavior),
-      one may need to apply more custom logic than what Configy does.
-      For this use case, one can define a `fromYAML` static method in the type:
-      `static S fromYAML(scope ConfigParser!S parser)`, where `S` is the type of
-      the enclosing structure. Structs with `fromYAML` will have this method
-      called instead of going through the normal parsing rules.
-      The `ConfigParser` exposes the current path of the field, as well as the
-      raw YAML `Node` itself, allowing for maximum flexibility.
-
     Composite_Types:
       Processing starts from a `struct` at the top level, and recurse into
       every fields individually. If a field is itself a struct,
@@ -42,10 +30,10 @@
         be thrown with an error message detailing where the issue happened.
       - If the field has no value and is optional, the default value will
         be used.
-      - If the type has a `static` method named `fromYAML` whose sole
-        non-default argument is a `configy.attributes : ConfigParser!S` (where
-        `S` is the type of the struct), this hook will called to handle
-        deserialization. This is the prefered method to handle complex logic.
+      - If the type has a `static` method named `fromConfig` whose sole
+        non-default argument is a `configy.attributes : ConfigParser`, this hook
+        will called to handle deserialization. This is the prefered method to
+        handle complex logic.
       - If the type has a `static` method named `fromString` whose sole argument
         is a `string`, it will be used.
       - If the type has a constructor whose sole argument is a `string`,
@@ -53,6 +41,17 @@
       - Finally, the filler will attempt to deserialize all struct members
         one by one and pass them to the default constructor, if there is any.
       - If none of the above succeeded, a `static assert` will trigger.
+
+    fromConfig:
+      Because config structs may contain complex types outside of the project's
+      control (e.g. a Phobos type, Vibe.d's `URL`, etc...) or one may want
+      the config format to be more dynamic (e.g. by exposing union-like behavior),
+      one may need to apply more custom logic than what Configy does.
+      For this use case, one can define a `fromConfig` static method in the type:
+      `static S fromConfig(scope ConfigParser parser)`. Structs with `fromConfig`
+      will have this method called instead of going through the normal parsing
+      rules. The `ConfigParser` exposes the current path of the field, as well
+      as the raw `Node` itself, allowing for maximum flexibility.
 
     Alias_this:
       If a `struct` contains an `alias this`, the field that is aliased will be
@@ -515,7 +514,7 @@ private TLFR.Type parseMapping (alias TLFR)
     happen here.
 
     Because a `struct` can be filled from either a mapping or a scalar,
-    this function will first try the fromYAML / fromString / string ctor
+    this function will first try the fromConfig / fromString / string ctor
     methods before defaulting to fieldwise construction.
 
     Note that optional fields are checked before recursion happens,
@@ -536,10 +535,10 @@ package FR.Type parseField (alias FR)
             parseField!(FieldRef!(FR.Type, "value"))(node, path, defaultValue, ctx),
             true);
 
-    else static if (hasFromYAML!(FR.Type))
+    else static if (hasFromConfig!(FR.Type))
     {
-        scope impl = new ConfigParserImpl!(FR.Type)(node, path, ctx);
-        return wrapConstruct(FR.Type.fromYAML(impl), path, node.location());
+        scope impl = new ConfigParserImpl(node, path, ctx);
+        return wrapConstruct(FR.Type.fromConfig(impl), path, node.location());
     }
 
     else static if (hasFromString!(FR.Type))
@@ -672,8 +671,8 @@ package FR.Type parseField (alias FR)
     }
     else
     {
-        static assert (!is(FR.Type == union),
-                       "`union` are not supported. Use a `struct` with `fromYAML` instead");
+        static assert (!is(FR.Type == union), "`union` are not supported. " ~
+            "Use a `struct` with a hook (`fromConfig`, `fromString`, string constructor) instead");
         return node.parseScalar!(FR.Type)(path);
     }
 }
@@ -779,9 +778,9 @@ private struct DurationMapping
 private enum mightBeOptional (alias FR) = is(FR.Type == struct) &&
     !is(immutable(FR.Type) == immutable(core.time.Duration)) &&
     !hasFromString!(FR.Type) && !hasStringCtor!(FR.Type) &&
-    !hasFromYAML!(FR.Type);
+    !hasFromConfig!(FR.Type);
 
-private final class ConfigParserImpl (T) : ConfigParser!T
+private final class ConfigParserImpl : ConfigParser
 {
     private Node node_;
     private string path_;
@@ -889,7 +888,7 @@ private template hasFieldWiseCtor (alias FR)
 }
 
 /// Evaluates to `true` if `T` has a static method that is designed to work with this library
-private enum hasFromYAML (T) = is(typeof(T.fromYAML(ConfigParser!(T).init)) : T);
+private enum hasFromConfig (T) = is(typeof(T.fromConfig(ConfigParser.init)) : T);
 
 /// Evaluates to `true` if `T` has a static method that accepts a `string` and returns a `T`
 private enum hasFromString (T) = is(typeof(T.fromString(string.init)) : T);

--- a/tests/unit/configy/yaml.d
+++ b/tests/unit/configy/yaml.d
@@ -720,7 +720,7 @@ unittest
     version(none) auto c2 = parseConfigString!Config2(null, null);
 }
 
-/// Test support for `fromYAML` hook
+/// Test support for `fromConfig` hook
 unittest
 {
     static struct PackageDef
@@ -735,7 +735,7 @@ unittest
         string path;
         PackageDef def;
 
-        public static Package fromYAML (scope ConfigParser!Package parser)
+        public static Package fromConfig (scope ConfigParser parser)
         {
             if (parser.node.type() == parser.node.Type.Mapping)
                 return Package(null, parser.parseAs!PackageDef);
@@ -769,7 +769,7 @@ deps:
     assert(c.deps[3] == Package("/one/last/path"));
 }
 
-/// Test top level hook (fromYAML / fromString)
+/// Test top level hook (fromConfig / fromString)
 unittest
 {
     static struct Version1 {
@@ -789,7 +789,7 @@ unittest
             Version1 v1;
             Version2 v2;
         }
-        static Config fromYAML (scope ConfigParser!Config parser)
+        static Config fromConfig (scope ConfigParser parser)
         {
             static struct OnlyVersion { uint fileVersion; }
             auto vers = parseConfig!OnlyVersion(parser.node, StrictMode.Ignore);
@@ -984,7 +984,7 @@ right:
     assert(c.right.value == 2);
 }
 
-/// Documentation for `fromYAML`
+/// Documentation for `fromConfig`
 unittest {
     import std.exception;
     import std.sumtype;
@@ -1004,7 +1004,7 @@ unittest {
     static struct Config {
         SumType!(ServiceConfig, JobConfig) conf;
 
-        static Config fromYAML(scope ConfigParser!Config parser) {
+        static Config fromConfig (scope ConfigParser parser) {
             auto mapping = parser.node.asMapping();
             return mapping.withNode("type", (scope Node key, scope Node typeN) {
                 // This will point to the start of the file / section


### PR DESCRIPTION
The `ConfigParser` no longer need to be templated since the introduction of an extra abstraction layer (`configy.backend.node : Node`). The name `fromConfig` is also a better fit now that Configy is no longer limited to YAML.