### PR TITLE
doc(read): Slightly rephrase to avoid 'and:' turning into a section

### DIFF
--- a/source/configy/read.d
+++ b/source/configy/read.d
@@ -71,13 +71,13 @@
       in `core.time`: `weeks`, `days`, `hours`, `minutes`, `seconds`, `msecs`,
       `usecs`, `hnsecs`, `nsecs`. Strict parsing option will be respected.
       The values of the fields will then be added together, so the following
-      YAML usages are equivalent:
+      YAML usage:
       ---
       // sleepFor:
       //   hours: 8
       //   minutes: 30
       ---
-      and:
+      is equivalent to the less human-friendly version:
       ---
       // sleepFor:
       //   minutes: 510


### PR DESCRIPTION
Sections in DDOC are a single word followed by ':' which this triggered.